### PR TITLE
Do not fail on OSCI warning codes like 3802

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,8 +562,9 @@ OsciMailbox.resource[IO](mailboxConfig, certManager, alias)
 ### Laufzettel
 
 Each `request` / `send` produces a `Laufzettel(messageId, timestamp,
-recipientAgs, recipientUri, status, rawXml)` handed to a `LaufzettelSink[F]`
-(for `send`, `rawXml` is empty — there is no response payload at store time):
+recipientAgs, recipientUri, status, rawXml, warnings)` handed to a
+`LaufzettelSink[F]` (for `send`, `rawXml` is empty — there is no response
+payload at store time):
 
 ```scala
 LaufzettelSink.console[IO]   // prints a one-line summary
@@ -585,10 +586,28 @@ All failures are an `OsciError` (a `RuntimeException`):
 | `RecipientCertMissing` | the service description has no cipher certificate |
 | `ServiceElementMissing`| the `OSCI_ADDRESSEE` / `OSCI_INTERMEDIARY` element is absent |
 | `OsciTransport`        | osci-bibliothek transport / IO failure |
-| `OsciResponse`         | OSCI returned a non-`0` feedback code |
+| `OsciResponse`         | OSCI returned an error (`9xxx`) feedback code |
 | `NoSuchMessage`        | `fetch(messageId)` found no content for that id |
 | `Certificate`          | cert / key decoding failure |
 | `Config`               | bad configuration (invalid URI, unknown cert type, …) |
+
+#### OSCI feedback codes
+
+OSCI-Transport 1.2 classifies feedback (Rückmeldungen) by the first digit of
+the four-digit code:
+
+| Class  | Meaning | Handling |
+|--------|---------|----------|
+| `0xxx` | success | normal result |
+| `3xxx` | warning — the request **was** executed | tolerated; surfaced as `OsciFeedback(code, text)` in `OsciReceipt.warnings` and `Laufzettel.warnings` |
+| `9xxx` | error — the request was not executed | raised as `OsciError.OsciResponse` |
+
+All feedback rows are inspected, so an error behind a per-language duplicate
+row fails too. A common warning is `3802` ("Signatur des Empfängers über die
+Annahme- bzw. Bearbeitungsantwort fehlt"): the recipient's gateway answered
+without signing its response. The response payload is still delivered — only
+the cryptographic proof over the recipient's answer is missing, which the
+`warnings` list lets you log or escalate per your own policy.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ libraryDependencies += "de.thatscalaguy" %% "zustellix-utils" % "0.2.0"
 > (the unused `category` / `requestTimeout` fields are gone);
 > `OSCIXMeldFacade` → `OsciFacade`; `OSCIXMeldError` → `OsciError`.
 
-> **Migrating to 0.3.x:** feedback handling is now OSCI-1.2-conformant —
+> **Migrating to 0.4.x:** feedback handling is now OSCI-1.2-conformant —
 > `3xxx` codes are warnings, not errors (see
 > [OSCI feedback codes](#osci-feedback-codes)). When upgrading:
 >

--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ libraryDependencies += "de.thatscalaguy" %% "zustellix-utils" % "0.2.0"
 > (the unused `category` / `requestTimeout` fields are gone);
 > `OSCIXMeldFacade` → `OsciFacade`; `OSCIXMeldError` → `OsciError`.
 
+> **Migrating to 0.3.x:** feedback handling is now OSCI-1.2-conformant —
+> `3xxx` codes are warnings, not errors (see
+> [OSCI feedback codes](#osci-feedback-codes)). When upgrading:
+>
+> - `OsciReceipt` and `Laufzettel` gained a
+>   `warnings: List[OsciFeedback] = Nil` field. Construction and field
+>   access compile unchanged; pattern matches that destructure every field
+>   need the new one, and codecs/schemas derived from the case-class shape
+>   (circe, doobie, a DB table mirroring `Laufzettel`) must add it.
+> - `request` / `send` no longer raise `OsciError.OsciResponse` for `3xxx`
+>   feedback (e.g. `3802` "Signatur des Empfängers über die Annahme- bzw.
+>   Bearbeitungsantwort fehlt") — the call succeeds and the codes land in
+>   `warnings`. Move alerting/retry logic keyed on that exception to
+>   inspecting `warnings`; a remaining `OsciResponse` is a real `9xxx`
+>   failure. `Laufzettel.status` can now carry a `3xxx` code, so
+>   "starts with `0` = success" checks must accept `0xxx` **and** `3xxx`
+>   as delivered.
+> - All feedback rows are scanned now: a `9xxx` error behind a per-language
+>   duplicate row raises where it previously slipped through, and the
+>   mailbox's `pending` / `fetch` no longer abort on `3800` / `3801`
+>   ("more available than the fetch limit").
+
 ---
 
 ## `utils` — certificates

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.3"
+ThisBuild / tlBaseVersion := "0.4"
 ThisBuild / scalaVersion := "3.3.6"
 ThisBuild / organization := "de.thatscalaguy"
 ThisBuild / organizationName := "ThatScalaGuy"

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/Laufzettel.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/Laufzettel.scala
@@ -9,5 +9,6 @@ final case class Laufzettel(
     recipientAgs: String,
     recipientUri: URI,
     status:       String,
-    rawXml:       String
+    rawXml:       String,
+    warnings:     List[OsciFeedback] = Nil
 )

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/LaufzettelSink.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/LaufzettelSink.scala
@@ -12,9 +12,12 @@ object LaufzettelSink {
     new LaufzettelSink[F] {
       def record(tenant: TenantId, l: Laufzettel): F[Unit] =
         Sync[F].delay {
+          val warnings =
+            if l.warnings.isEmpty then ""
+            else l.warnings.map(_.code).mkString(" warnings=", ",", "")
           println(
             s"[Laufzettel tenant=${tenant.value} ags=${l.recipientAgs} " +
-              s"messageId=${l.messageId} status=${l.status} " +
+              s"messageId=${l.messageId} status=${l.status}$warnings " +
               s"uri=${l.recipientUri} at=${l.timestamp}]"
           )
         }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciFeedback.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciFeedback.scala
@@ -1,0 +1,14 @@
+package de.thatscalaguy.zustellix.osci
+
+/** One OSCI feedback entry (Rückmeldung) of the warning class.
+ *
+ *  OSCI-Transport 1.2 classifies feedback codes by their first digit:
+ *  `0xxx` = success, `3xxx` = warning (the request WAS executed), `9xxx` =
+ *  error (the request was not executed). Warnings — e.g. `3802` "Signatur
+ *  des Empfängers über die Annahme- bzw. Bearbeitungsantwort fehlt" — do not
+ *  fail the call; they are surfaced here so callers can log or act on them.
+ *
+ *  @param code four-digit OSCI feedback code (e.g. "3802")
+ *  @param text human-readable text as sent by the intermediary
+ */
+final case class OsciFeedback(code: String, text: String)

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciReceipt.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciReceipt.scala
@@ -10,9 +10,13 @@ import java.time.Instant
  *                   handle for any later process-card inquiry
  *  @param status    top OSCI feedback code (e.g. "0800")
  *  @param creation  intermediary's creation timestamp from the process card
+ *  @param warnings  warning-class (`3xxx`) feedback entries — the request was
+ *                   executed, but the intermediary flagged something (e.g.
+ *                   a certificate validity warning)
  */
 final case class OsciReceipt(
     messageId: String,
     status:    String,
-    creation:  Option[Instant]
+    creation:  Option[Instant],
+    warnings:  List[OsciFeedback] = Nil
 )

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibBridge.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibBridge.scala
@@ -122,7 +122,8 @@ private[osci] final class OsciBibBridgeImpl[F[_]: Sync](
           responseXml = extractXml(rsp.getContentContainer, rsp.getEncryptedData, originator)
             .getOrElse(""),
           messageId = msgIdResp.getMessageId,
-          status    = topFeedbackCode(rsp.getFeedback)
+          status    = topFeedbackCode(rsp.getFeedback),
+          warnings  = feedbackWarnings(rsp.getFeedback)
         )
       }
       catch {
@@ -158,7 +159,8 @@ private[osci] final class OsciBibBridgeImpl[F[_]: Sync](
         OsciReceipt(
           messageId = msgIdResp.getMessageId,
           status    = topFeedbackCode(rsp.getFeedback),
-          creation  = parseTimestamp(rsp.getTimestampCreation)
+          creation  = parseTimestamp(rsp.getTimestampCreation),
+          warnings  = feedbackWarnings(rsp.getFeedback)
         )
       }
       catch {

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupport.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupport.scala
@@ -1,6 +1,6 @@
 package de.thatscalaguy.zustellix.osci.internal
 
-import de.thatscalaguy.zustellix.osci.OsciError
+import de.thatscalaguy.zustellix.osci.{OsciError, OsciFeedback}
 
 import de.osci.osci12.OSCIException
 import de.osci.osci12.messageparts.{Content, ContentContainer, EncryptedDataOSCI, Timestamp}
@@ -16,21 +16,42 @@ import scala.util.Try
  */
 private[osci] object OsciBibSupport {
 
-  // OSCI feedback rows are [lang, code, text]; a code starting with "0" means
-  // success. Only row 0 is inspected — a documented residual gap, see
-  // OsciBibSupportSpec.
+  // OSCI feedback rows are [lang, code, text]. OSCI 1.2 classifies codes by
+  // their first digit: "0" = success, "3" = warning (the request WAS
+  // executed — e.g. 3802 "recipient signature over the acceptance/processing
+  // response missing"), "9" = error (the request was not executed). Warnings
+  // must not fail the call; they are surfaced via feedbackWarnings. All rows
+  // are scanned — an error in a later row (e.g. behind a per-language
+  // duplicate of row 0) fails too.
   def checkFeedback(fb: Array[Array[String]]): Unit =
-    Option(fb).filter(_.nonEmpty).map(_(0)) match {
-      case Some(row) if row.length >= 2 && row(1) != null && !row(1).startsWith("0") =>
+    feedbackRows(fb).foreach { row =>
+      if row.length >= 2 && row(1) != null
+        && !row(1).startsWith("0") && !row(1).startsWith("3")
+      then {
         val detail = if row.length >= 3 then Option(row(2)).getOrElse("") else ""
         throw OsciError.OsciResponse(row(1), detail)
-      case _ => ()
+      }
     }
 
+  /** Warning-class (`3xxx`) feedback entries, deduplicated by code — the
+   *  intermediary usually repeats the same code once per requested language.
+   */
+  def feedbackWarnings(fb: Array[Array[String]]): List[OsciFeedback] =
+    feedbackRows(fb)
+      .collect {
+        case row if row.length >= 2 && row(1) != null && row(1).startsWith("3") =>
+          val text = if row.length >= 3 then Option(row(2)).getOrElse("") else ""
+          OsciFeedback(row(1), text)
+      }
+      .distinctBy(_.code)
+
   def topFeedbackCode(fb: Array[Array[String]]): String =
-    Option(fb).filter(_.nonEmpty).flatMap(_.headOption).flatMap { r =>
+    feedbackRows(fb).headOption.flatMap { r =>
       if r.length >= 2 then Option(r(1)) else None
     }.getOrElse("")
+
+  private def feedbackRows(fb: Array[Array[String]]): List[Array[String]] =
+    Option(fb).map(_.toList).getOrElse(Nil).filter(_ != null)
 
   def firstContentData(ccs: List[ContentContainer]): Option[String] =
     ccs.iterator

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
@@ -23,7 +23,8 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
                   recipientAgs = ags,
                   recipientUri = route.addresseeUri,
                   status       = result.status,
-                  rawXml       = result.responseXml
+                  rawXml       = result.responseXml,
+                  warnings     = result.warnings
                 )
       _      <- sink.record(tenantId, lz).attempt.void
     }
@@ -40,7 +41,8 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
                    recipientAgs = ags,
                    recipientUri = route.addresseeUri,
                    status       = receipt.status,
-                   rawXml       = "" // async: no response payload at store time
+                   rawXml       = "", // async: no response payload at store time
+                   warnings     = receipt.warnings
                  )
       _       <- sink.record(tenantId, lz).attempt.void
     }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciTransport.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciTransport.scala
@@ -1,6 +1,6 @@
 package de.thatscalaguy.zustellix.osci.internal
 
-import de.thatscalaguy.zustellix.osci.OsciReceipt
+import de.thatscalaguy.zustellix.osci.{OsciFeedback, OsciReceipt}
 
 import java.net.URI
 import java.security.cert.X509Certificate
@@ -26,7 +26,8 @@ final case class OsciRoute(
 final case class OsciRawResult(
     responseXml: String,
     messageId:   String,
-    status:      String
+    status:      String,
+    warnings:    List[OsciFeedback] = Nil
 )
 
 /** Narrow mockable seam over the Governikus osci-bibliothek Java library for

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupportSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupportSpec.scala
@@ -1,6 +1,6 @@
 package de.thatscalaguy.zustellix.osci.internal
 
-import de.thatscalaguy.zustellix.osci.OsciError
+import de.thatscalaguy.zustellix.osci.{OsciError, OsciFeedback}
 import munit.FunSuite
 
 import de.osci.osci12.messageparts.{Content, ContentContainer, EncryptedDataOSCI, Timestamp}
@@ -42,9 +42,10 @@ class OsciBibSupportSpec extends FunSuite {
 
   private lazy val role = new Originator(cert, cert)
 
-  // OSCI feedback rows are [lang, code, text]; code "0..." means success.
+  // OSCI feedback rows are [lang, code, text]. OSCI 1.2 code classes:
+  // "0xxx" = success, "3xxx" = warning (request executed), "9xxx" = error.
 
-  test("checkFeedback: a non-\"0\" code in row 0 raises OsciResponse(code, detail)") {
+  test("checkFeedback: a \"9...\" error code in row 0 raises OsciResponse(code, detail)") {
     val fb = Array(Array("de", "9000", "boom"))
     interceptMessage[OsciError.OsciResponse]("OSCI response error [9000]: boom") {
       checkFeedback(fb)
@@ -53,6 +54,17 @@ class OsciBibSupportSpec extends FunSuite {
 
   test("checkFeedback: a \"0...\" success code in row 0 does not raise") {
     checkFeedback(Array(Array("de", "0800", "ok"))) // no exception
+  }
+
+  test("checkFeedback: a \"3...\" warning code does not raise (request was executed)") {
+    // 3802 = recipient signature over acceptance/processing response missing.
+    checkFeedback(Array(Array("en", "3802", "Signature of the recipient ... is missing")))
+  }
+
+  test("checkFeedback: an unknown code class is treated as an error") {
+    interceptMessage[OsciError.OsciResponse]("OSCI response error [X999]: strange") {
+      checkFeedback(Array(Array("de", "X999", "strange")))
+    }
   }
 
   test("checkFeedback: null / empty feedback is tolerated") {
@@ -70,24 +82,51 @@ class OsciBibSupportSpec extends FunSuite {
     assertEquals(topFeedbackCode(Array.empty[Array[String]]), "")
   }
 
-  // RESIDUAL GAP (documented, not ideal): checkFeedback and topFeedbackCode
-  // only ever inspect row 0. An error code sitting in a LATER feedback row is
-  // NOT surfaced today. We assert the CURRENT behaviour so a future fix that
-  // scans all rows will flip these expectations on purpose.
-  test("checkFeedback ignores an error in a LATER row (row 0 only — current behaviour)") {
+  test("checkFeedback scans ALL rows: an error in a LATER row raises") {
     val fb = Array(
       Array("de", "0800", "envelope ok"),
       Array("de", "9000", "inner error in a later row")
     )
-    checkFeedback(fb) // does NOT raise, because only row 0 is read
+    interceptMessage[OsciError.OsciResponse]("OSCI response error [9000]: inner error in a later row") {
+      checkFeedback(fb)
+    }
   }
 
-  test("topFeedbackCode returns row-0 code even when a later row carries an error (current behaviour)") {
+  test("checkFeedback: a warning alongside a success code still does not raise") {
     val fb = Array(
       Array("de", "0800", "envelope ok"),
-      Array("de", "9000", "inner error in a later row")
+      Array("de", "3802", "Signatur des Empfängers fehlt")
+    )
+    checkFeedback(fb)
+  }
+
+  test("topFeedbackCode returns the row-0 code regardless of later rows") {
+    val fb = Array(
+      Array("de", "0800", "envelope ok"),
+      Array("de", "3802", "warning in a later row")
     )
     assertEquals(topFeedbackCode(fb), "0800")
+  }
+
+  test("feedbackWarnings collects 3xxx rows and dedups per-language repeats") {
+    val fb = Array(
+      Array("de", "3802", "Signatur des Empfängers über die Annahme- bzw. Bearbeitungsantwort fehlt"),
+      Array("en", "3802", "Signature of the recipient over the acceptance response or processing response is missing"),
+      Array("de", "3500", "Zertifikat zeitlich ungültig")
+    )
+    assertEquals(
+      feedbackWarnings(fb),
+      List(
+        OsciFeedback("3802", "Signatur des Empfängers über die Annahme- bzw. Bearbeitungsantwort fehlt"),
+        OsciFeedback("3500", "Zertifikat zeitlich ungültig")
+      )
+    )
+  }
+
+  test("feedbackWarnings ignores success/error rows and tolerates null / empty feedback") {
+    assertEquals(feedbackWarnings(Array(Array("de", "0800", "ok"))), Nil)
+    assertEquals(feedbackWarnings(null), Nil)
+    assertEquals(feedbackWarnings(Array.empty[Array[String]]), Nil)
   }
 
   test("firstContentData returns the first non-empty content payload") {

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
@@ -80,6 +80,29 @@ class OsciClientImplSpec extends CatsEffectSuite {
     }
   }
 
+  test("feedback warnings from the transport land on the Laufzettel") {
+    val warning = OsciFeedback("3802", "Signatur des Empfängers fehlt")
+    val raw     = OsciRawResult("<resp/>", "msg-1", "3802", List(warning))
+    Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
+      val impl = new OsciClientImpl[IO](
+        TenantId("alice"),
+        "XMeld",
+        fixedTransport(raw),
+        fixedResolver(Route),
+        recordingSink(ref)
+      )
+      for {
+        out  <- impl.request(Ags, "<req/>")
+        seen <- ref.get
+      }
+      yield {
+        assertEquals(out, "<resp/>")
+        assertEquals(seen.head.status, "3802")
+        assertEquals(seen.head.warnings, List(warning))
+      }
+    }
+  }
+
   test("AgsNotInDvdv from resolver bubbles up") {
     val impl = new OsciClientImpl[IO](
       TenantId("alice"),


### PR DESCRIPTION
## What is the problem?

The OSCI intermediary can answer with a warning code like `3802` ("signature of the recipient is missing"). A warning means the request **did work**. But this library treated the warning like an error. It threw an exception and the response was lost. Other software (ProGov) accepts the same answer without a problem.

## What does this change?

- Warning codes (`3xxx`) no longer stop the request. The response is returned as normal.
- Warnings are not hidden: they are saved in a new `warnings` field on `OsciReceipt` and on the `Laufzettel`, so you can log them or alert on them.
- Real errors (`9xxx`, or unknown codes) still throw an error. All feedback rows are now checked, not only the first one.
- The README now explains the OSCI feedback code classes and has migration notes for 0.4.x.
- `tlBaseVersion` is bumped to `0.4`: the new `warnings` field changes the case-class constructor signatures, so the change is binary-incompatible with the released 0.3.0. Under early-semver it must ship as 0.4.0 (this is also what MiMa in CI enforces).

## Tests

All tests pass (`sbt test`, 131 tests). New tests cover: 3802 is tolerated, errors in later rows are found, warnings land on the Laufzettel. `sbt mimaReportBinaryIssues` passes.