### PR TITLE
osci: add HTTP timeouts and a pluggable TransportI

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,50 @@ the intermediary after reception (subject to its retention policy).
 One mailbox can serve several profiles; filter on `PendingDelivery.subject`
 client-side if you need to split them.
 
+### HTTP timeouts and custom transport
+
+All wire operations go through an `OsciHttpTransport` — a drop-in for
+osci-bibliothek's sample `HttpTransport` that additionally sets a connect and
+a read timeout on every `HttpURLConnection`, so a stalled intermediary
+surfaces as an `OsciError.OsciTransport` instead of blocking the calling thread
+forever (the bridges run inside `Sync[F].blocking`, which cannot be
+cancelled once started). Both timeouts are configurable per client/mailbox
+and default to 10 s connect / 120 s read:
+
+```scala
+import scala.concurrent.duration.*
+
+val osciConfig = OsciConfig(
+  tenantId       = TenantId("flensburg"),
+  certSource     = Some(cert),
+  connectTimeout = 5.seconds,
+  readTimeout    = 60.seconds
+)
+
+val mailboxConfig = OsciMailboxConfig(
+  intermedUri        = URI.create("https://intermed.example/osci-manager"),
+  intermedCipherCert = intermedCert,
+  connectTimeout     = 5.seconds,
+  readTimeout        = 60.seconds
+)
+```
+
+Note that `readTimeout` bounds each blocking read, not the whole exchange —
+size it for the slowest expected synchronous round trip (`request` waits for
+the addressee's answer within the call).
+
+Both `OsciClient.resource` and `OsciMailbox.resource` also accept your own
+`de.osci.osci12.extinterfaces.TransportI` as a trailing argument (proxies,
+custom TLS, instrumentation, …); the config timeouts then do not apply — the
+transport owns its own settings:
+
+```scala
+val myTransport: de.osci.osci12.extinterfaces.TransportI = ...
+
+OsciClient.resource[IO](osciConfig, dvdv, LaufzettelSink.console[IO], myTransport)
+OsciMailbox.resource[IO](mailboxConfig, cert, myTransport)
+```
+
 ### Multi-tenant facade
 
 `OsciFacade` dispatches `request` / `send` by tenant. Build it from a
@@ -545,11 +589,13 @@ OsciFacade.fromConfigs[IO](src, dvdvFor, LaufzettelSink.console[IO]).use { facad
 Properties-file format for `ConfigSource.file`:
 
 ```properties
-tenant.flensburg.cert.type     = pkcs12
-tenant.flensburg.cert.path     = /secrets/flensburg.p12
-tenant.flensburg.cert.password = s3cret
-tenant.flensburg.serviceUri    = http://www.osci.de/xmeld2605/xmeld2605Personensuche.wsdl
-tenant.flensburg.subject       = XMeld
+tenant.flensburg.cert.type        = pkcs12
+tenant.flensburg.cert.path        = /secrets/flensburg.p12
+tenant.flensburg.cert.password    = s3cret
+tenant.flensburg.serviceUri       = http://www.osci.de/xmeld2605/xmeld2605Personensuche.wsdl
+tenant.flensburg.subject          = XMeld
+tenant.flensburg.connectTimeoutMs = 5000
+tenant.flensburg.readTimeoutMs    = 60000
 
 tenant.kiel.cert.type     = pem
 tenant.kiel.cert.path     = /secrets/kiel-cert.pem
@@ -558,7 +604,8 @@ tenant.kiel.cert.password = optional-key-password
 ```
 
 (`serviceUri` and `subject` are optional and default to the XMeld
-Personensuche WSDL and `XMeld`.)
+Personensuche WSDL and `XMeld`; `connectTimeoutMs` / `readTimeoutMs` are
+optional and default to 10 s / 120 s.)
 
 Multi-tenant mailboxes are simply multiple `OsciMailbox.resource` calls — one
 per tenant cert/intermediary.

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciClient.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciClient.scala
@@ -5,6 +5,8 @@ import cats.syntax.all.*
 import de.thatscalaguy.zustellix.dvdv.DvdvClient
 import de.thatscalaguy.zustellix.utils.cert.{CertManager, CertAlias}
 
+import de.osci.osci12.extinterfaces.TransportI
+
 trait OsciClient[F[_]] {
 
   /** Synchronous request/response (`MediateDelivery`): the recipient answers
@@ -32,11 +34,27 @@ object OsciClient {
    *
    *  The given DvdvClient is owned by the caller; this resource does not
    *  close it.
+   *
+   *  Uses an [[OsciHttpTransport]] with the config's `connectTimeout` /
+   *  `readTimeout` on the wire; the `transport` overload swaps it for a
+   *  custom one.
    */
   def resource[F[_]: Async](
       config: OsciConfig,
       dvdv:   DvdvClient[F],
       sink:   LaufzettelSink[F]
+  ): Resource[F, OsciClient[F]] =
+    resource(config, dvdv, sink, defaultTransport(config))
+
+  /** Same as the 3-arg overload, but sends over the given `transport` instead
+   *  of the default [[OsciHttpTransport]] (the config's timeouts then do not
+   *  apply — the transport owns its own settings).
+   */
+  def resource[F[_]: Async](
+      config:    OsciConfig,
+      dvdv:      DvdvClient[F],
+      sink:      LaufzettelSink[F],
+      transport: TransportI
   ): Resource[F, OsciClient[F]] = {
     val resolver = internal.AgsResolver[F](dvdv, config)
     val certSource = config.certSource.liftTo[F](
@@ -44,8 +62,9 @@ object OsciClient {
         "OsciConfig.certSource is not set — set it, or use the CertManager/CertAlias overload"
       )
     )
-    Resource.eval(certSource).flatMap(internal.OsciBibBridge.resource[F](_)).map { transport =>
-      new internal.OsciClientImpl[F](config.tenantId, config.subject, transport, resolver, sink)
+    Resource.eval(certSource).flatMap(internal.OsciBibBridge.resource[F](_, transport)).map {
+      bridge =>
+        new internal.OsciClientImpl[F](config.tenantId, config.subject, bridge, resolver, sink)
     }
   }
 
@@ -60,13 +79,29 @@ object OsciClient {
       alias:  CertAlias,
       dvdv:   DvdvClient[F],
       sink:   LaufzettelSink[F]
+  ): Resource[F, OsciClient[F]] =
+    resource(config, certs, alias, dvdv, sink, defaultTransport(config))
+
+  /** Same as the CertManager overload, but sends over the given `transport`
+   *  instead of the default [[OsciHttpTransport]].
+   */
+  def resource[F[_]: Async](
+      config:    OsciConfig,
+      certs:     CertManager[F],
+      alias:     CertAlias,
+      dvdv:      DvdvClient[F],
+      sink:      LaufzettelSink[F],
+      transport: TransportI
   ): Resource[F, OsciClient[F]] = {
     val resolver = internal.AgsResolver[F](dvdv, config)
     for {
-      cred      <- Resource.eval(certs.resolve(alias))
-      transport <- internal.OsciBibBridge.resource[F](cred)
+      cred   <- Resource.eval(certs.resolve(alias))
+      bridge <- internal.OsciBibBridge.resource[F](cred, transport)
     } yield new internal.OsciClientImpl[F](
-      TenantId(alias.value), config.subject, transport, resolver, sink
+      TenantId(alias.value), config.subject, bridge, resolver, sink
     )
   }
+
+  private def defaultTransport(config: OsciConfig): TransportI =
+    new OsciHttpTransport(config.connectTimeout, config.readTimeout)
 }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciConfig.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciConfig.scala
@@ -2,12 +2,18 @@ package de.thatscalaguy.zustellix.osci
 
 import de.thatscalaguy.zustellix.utils.cert.CertSource
 
+import scala.concurrent.duration.FiniteDuration
+
 /** Outbound OSCI client configuration.
  *
  *  `serviceUri` selects the DVDV service description the recipient routes are
  *  resolved from; `subject` is the OSCI message subject. The defaults match
  *  the XMeld Personensuche profile — XFamilie (or other) profiles override
  *  both.
+ *
+ *  `connectTimeout` / `readTimeout` bound the default [[OsciHttpTransport]]'s
+ *  `HttpURLConnection`s; they are ignored when a custom transport is passed
+ *  to `OsciClient.resource`.
  */
 final case class OsciConfig(
     tenantId: TenantId,
@@ -17,7 +23,9 @@ final case class OsciConfig(
      */
     certSource: Option[CertSource] = None,
     serviceUri: String = OsciConfig.DefaultXMeldServiceUri,
-    subject: String = OsciConfig.DefaultSubject
+    subject: String = OsciConfig.DefaultSubject,
+    connectTimeout: FiniteDuration = OsciHttpTransport.DefaultConnectTimeout,
+    readTimeout: FiniteDuration = OsciHttpTransport.DefaultReadTimeout
 )
 
 object OsciConfig {

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciHttpTransport.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciHttpTransport.scala
@@ -1,0 +1,87 @@
+package de.thatscalaguy.zustellix.osci
+
+import de.osci.osci12.extinterfaces.TransportI
+
+import java.io.{IOException, InputStream, OutputStream}
+import java.net.{HttpURLConnection, MalformedURLException, URI, URLConnection}
+import scala.concurrent.duration.*
+
+/** HTTP transport for osci-bibliothek with connect and read timeouts.
+ *
+ *  Functional copy of the library's sample
+ *  `de.osci.osci12.samples.impl.HttpTransport`, which opens its
+ *  `HttpURLConnection`s without any timeout: a stalled intermediary blocks
+ *  the calling thread forever — and the bridges run inside
+ *  `Sync[F].blocking`, which cannot be cancelled once started. This variant
+ *  applies `connectTimeout` and `readTimeout` to every connection it opens,
+ *  so a dead or hanging endpoint surfaces as a `SocketTimeoutException`
+ *  (mapped to an [[OsciError.OsciTransport]] by the bridges) instead.
+ *
+ *  osci-bibliothek clones the transport per request via [[newInstance]]; the
+ *  clone carries the same timeouts. Note that `readTimeout` bounds each
+ *  blocking read, not the whole exchange — size it for the slowest expected
+ *  synchronous round trip (`MediateDelivery` waits for the addressee's
+ *  answer within the call).
+ */
+final class OsciHttpTransport(
+    val connectTimeout: FiniteDuration,
+    val readTimeout:    FiniteDuration
+) extends TransportI {
+
+  private var con: URLConnection = null
+
+  override def getVendor: String  = "ThatScalaGuy"
+  override def getVersion: String = "1.0"
+
+  override def newInstance(): TransportI =
+    new OsciHttpTransport(connectTimeout, readTimeout)
+
+  override def getResponseStream: InputStream = con.getInputStream
+
+  override def isOnline(uri: URI): Boolean =
+    try {
+      con = openConnection(uri)
+      con.connect()
+      true
+    } catch {
+      case e: MalformedURLException => throw invalidUrl(e)
+      case _: IOException           => false
+    }
+
+  override def getContentLength: Long =
+    throw new UnsupportedOperationException("getContentLength is not implemented")
+
+  override def getConnection(uri: URI, contentLength: Long): OutputStream =
+    try {
+      val http = openConnection(uri).asInstanceOf[HttpURLConnection]
+      http.setInstanceFollowRedirects(false)
+      http.setRequestMethod("POST")
+      http.setRequestProperty("Content-Type", "text/xml")
+      http.setRequestProperty("charset", "utf-8")
+      http.setRequestProperty("Content-Length", contentLength.toString)
+      http.setUseCaches(false)
+      http.setDoOutput(true)
+      con = http
+      http.getOutputStream
+    } catch {
+      case e: MalformedURLException => throw invalidUrl(e)
+    }
+
+  private[osci] def openConnection(uri: URI): URLConnection = {
+    val c = uri.toURL.openConnection()
+    c.setConnectTimeout(toMillisInt(connectTimeout))
+    c.setReadTimeout(toMillisInt(readTimeout))
+    c
+  }
+
+  private def toMillisInt(d: FiniteDuration): Int =
+    math.min(d.toMillis, Int.MaxValue.toLong).toInt
+
+  private def invalidUrl(e: MalformedURLException): IOException =
+    new IOException(s"invalid URL: ${e.getLocalizedMessage}", e)
+}
+
+object OsciHttpTransport {
+  val DefaultConnectTimeout: FiniteDuration = 10.seconds
+  val DefaultReadTimeout:    FiniteDuration = 120.seconds
+}

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMailbox.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMailbox.scala
@@ -3,6 +3,8 @@ package de.thatscalaguy.zustellix.osci
 import cats.effect.{Async, Resource}
 import de.thatscalaguy.zustellix.utils.cert.{CertAlias, CertManager, CertSource}
 
+import de.osci.osci12.extinterfaces.TransportI
+
 /** Our own mailbox at an OSCI intermediary — the asynchronous, passive
  *  recipient leg (e.g. XFamilie).
  *
@@ -34,12 +36,27 @@ trait OsciMailbox[F[_]] {
 
 object OsciMailbox {
 
+  /** Fetches over an [[OsciHttpTransport]] with the config's
+   *  `connectTimeout` / `readTimeout`; the `transport` overload swaps it for
+   *  a custom one.
+   */
   def resource[F[_]: Async](
       config:     OsciMailboxConfig,
       certSource: CertSource
   ): Resource[F, OsciMailbox[F]] =
+    resource(config, certSource, defaultTransport(config))
+
+  /** Same as the CertSource overload, but fetches over the given `transport`
+   *  instead of the default [[OsciHttpTransport]] (the config's timeouts then
+   *  do not apply — the transport owns its own settings).
+   */
+  def resource[F[_]: Async](
+      config:     OsciMailboxConfig,
+      certSource: CertSource,
+      transport:  TransportI
+  ): Resource[F, OsciMailbox[F]] =
     Resource.eval(internal.OsciBibBridge.originator[F](certSource)).map { originator =>
-      new internal.OsciMailboxBridgeImpl[F](originator, config)
+      new internal.OsciMailboxBridgeImpl[F](originator, config, transport)
     }
 
   /** Mailbox whose signing + decryption cert is resolved from the shared
@@ -51,8 +68,22 @@ object OsciMailbox {
       certs:  CertManager[F],
       alias:  CertAlias
   ): Resource[F, OsciMailbox[F]] =
+    resource(config, certs, alias, defaultTransport(config))
+
+  /** Same as the CertManager overload, but fetches over the given
+   *  `transport` instead of the default [[OsciHttpTransport]].
+   */
+  def resource[F[_]: Async](
+      config:    OsciMailboxConfig,
+      certs:     CertManager[F],
+      alias:     CertAlias,
+      transport: TransportI
+  ): Resource[F, OsciMailbox[F]] =
     for {
       cred       <- Resource.eval(certs.resolve(alias))
       originator <- Resource.eval(internal.OsciBibBridge.originator[F](cred))
-    } yield new internal.OsciMailboxBridgeImpl[F](originator, config)
+    } yield new internal.OsciMailboxBridgeImpl[F](originator, config, transport)
+
+  private def defaultTransport(config: OsciMailboxConfig): TransportI =
+    new OsciHttpTransport(config.connectTimeout, config.readTimeout)
 }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMailboxConfig.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMailboxConfig.scala
@@ -2,6 +2,7 @@ package de.thatscalaguy.zustellix.osci
 
 import java.net.URI
 import java.security.cert.X509Certificate
+import scala.concurrent.duration.FiniteDuration
 
 /** Static configuration of our own mailbox at an OSCI intermediary (the
  *  asynchronous, passive-recipient leg — e.g. XFamilie). Unlike outbound
@@ -12,9 +13,17 @@ import java.security.cert.X509Certificate
  *                            the envelope towards the intermediary)
  *  @param fetchLimit         maximum number of process cards one `pending`
  *                            call lists (`FetchProcessCard.setQuantityLimit`)
+ *  @param connectTimeout     HTTP connect timeout of the default
+ *                            [[OsciHttpTransport]]; ignored when a custom
+ *                            transport is passed to `OsciMailbox.resource`
+ *  @param readTimeout        HTTP read timeout of the default
+ *                            [[OsciHttpTransport]]; ignored when a custom
+ *                            transport is passed to `OsciMailbox.resource`
  */
 final case class OsciMailboxConfig(
     intermedUri:        URI,
     intermedCipherCert: X509Certificate,
-    fetchLimit:         Long = 100
+    fetchLimit:         Long = 100,
+    connectTimeout:     FiniteDuration = OsciHttpTransport.DefaultConnectTimeout,
+    readTimeout:        FiniteDuration = OsciHttpTransport.DefaultReadTimeout
 )

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/FileConfigSource.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/FileConfigSource.scala
@@ -7,6 +7,7 @@ import de.thatscalaguy.zustellix.osci.*
 import java.io.FileInputStream
 import java.nio.file.{Path, Paths}
 import java.util.Properties
+import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
 
 /** Loads tenant configurations from a Java properties file with keys of the form
@@ -18,6 +19,8 @@ import scala.jdk.CollectionConverters.*
  *   tenant.<id>.cert.keyPath           = <path>             (pem only)
  *   tenant.<id>.serviceUri             = <wsdl uri>          (optional)
  *   tenant.<id>.subject                = <osci subject>      (optional)
+ *   tenant.<id>.connectTimeoutMs       = <millis>            (optional)
+ *   tenant.<id>.readTimeoutMs          = <millis>            (optional)
  * }}}
  *
  *  The intermediary is no longer configured here — it is resolved per send
@@ -64,11 +67,22 @@ private[osci] final class FileConfigSource[F[_]: Sync](path: Path) extends Confi
         throw OsciError.Config(s"tenant.$id.cert.type must be 'pkcs12' or 'pem', got '$other'")
     }
 
+    def timeoutMs(k: String, default: FiniteDuration): FiniteDuration =
+      kv.get(k).fold(default) { v =>
+        v.trim.toLongOption.filter(_ > 0).map(_.millis).getOrElse(
+          throw OsciError.Config(
+            s"tenant.$id.$k must be a positive number of milliseconds, got '$v'"
+          )
+        )
+      }
+
     OsciConfig(
-      tenantId   = TenantId(id),
-      certSource = Some(certSource),
-      serviceUri = kv.getOrElse("serviceUri", OsciConfig.DefaultXMeldServiceUri),
-      subject    = kv.getOrElse("subject", OsciConfig.DefaultSubject)
+      tenantId       = TenantId(id),
+      certSource     = Some(certSource),
+      serviceUri     = kv.getOrElse("serviceUri", OsciConfig.DefaultXMeldServiceUri),
+      subject        = kv.getOrElse("subject", OsciConfig.DefaultSubject),
+      connectTimeout = timeoutMs("connectTimeoutMs", OsciHttpTransport.DefaultConnectTimeout),
+      readTimeout    = timeoutMs("readTimeoutMs", OsciHttpTransport.DefaultReadTimeout)
     )
   }
 }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibBridge.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibBridge.scala
@@ -15,7 +15,6 @@ import de.osci.osci12.messagetypes.{
   StoreDelivery
 }
 import de.osci.osci12.roles.{Addressee, Intermed, Originator}
-import de.osci.osci12.samples.impl.HttpTransport
 import de.osci.osci12.samples.impl.crypto.{PKCS12Decrypter, PKCS12Signer}
 
 import java.io.ByteArrayInputStream
@@ -24,14 +23,20 @@ import java.security.Security
 
 private[osci] object OsciBibBridge {
 
-  def resource[F[_]: Sync](certSource: CertSource): Resource[F, OsciTransport[F]] =
-    Resource.eval(originator[F](certSource)).map(new OsciBibBridgeImpl[F](_))
+  def resource[F[_]: Sync](
+      certSource: CertSource,
+      transport:  TransportI
+  ): Resource[F, OsciTransport[F]] =
+    Resource.eval(originator[F](certSource)).map(new OsciBibBridgeImpl[F](_, transport))
 
   /** Alias-keyed path: the same PKCS12 the DVDV client uses, supplied by the
    *  shared [[de.thatscalaguy.zustellix.utils.cert.CertManager]] as bytes.
    */
-  def resource[F[_]: Sync](cred: CertCredential): Resource[F, OsciTransport[F]] =
-    Resource.eval(originator[F](cred)).map(new OsciBibBridgeImpl[F](_))
+  def resource[F[_]: Sync](
+      cred:      CertCredential,
+      transport: TransportI
+  ): Resource[F, OsciTransport[F]] =
+    Resource.eval(originator[F](cred)).map(new OsciBibBridgeImpl[F](_, transport))
 
   /** Our own OSCI role: signer + decrypter from the tenant's PKCS12. Also
    *  used by the mailbox bridge, where the same role fetches and decrypts
@@ -84,7 +89,7 @@ private[osci] object OsciBibBridge {
 
 private[osci] final class OsciBibBridgeImpl[F[_]: Sync](
     originator: Originator,
-    transport: TransportI = new HttpTransport()
+    transport: TransportI
 ) extends OsciTransport[F] {
 
   import OsciBibSupport.*

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciMailboxBridge.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciMailboxBridge.scala
@@ -19,7 +19,6 @@ import de.osci.osci12.messagetypes.{
   OSCIMessage
 }
 import de.osci.osci12.roles.{Intermed, Originator}
-import de.osci.osci12.samples.impl.HttpTransport
 
 /** osci-bibliothek-backed mailbox. The same Originator role that signs the
  *  fetch dialog carries our Decrypter for the inbound payloads (they are
@@ -28,7 +27,7 @@ import de.osci.osci12.samples.impl.HttpTransport
 private[osci] final class OsciMailboxBridgeImpl[F[_]: Sync](
     originator: Originator,
     config:     OsciMailboxConfig,
-    transport:  TransportI = new HttpTransport()
+    transport:  TransportI
 ) extends OsciMailbox[F] {
 
   import OsciBibSupport.*

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/ConfigSourceSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/ConfigSourceSpec.scala
@@ -5,6 +5,7 @@ import de.thatscalaguy.zustellix.utils.cert.CertSource
 import munit.CatsEffectSuite
 
 import java.nio.file.{Files, Paths}
+import scala.concurrent.duration.*
 
 class ConfigSourceSpec extends CatsEffectSuite {
 
@@ -65,6 +66,51 @@ class ConfigSourceSpec extends CatsEffectSuite {
           assertEquals(pw, None)
         case other => fail(s"expected Pem, got $other")
       }
+    }
+  }
+
+  test("file parses optional timeouts and defaults them when absent") {
+    val props =
+      """tenant.alice.cert.type        = pkcs12
+        |tenant.alice.cert.path        = /keys/alice.p12
+        |tenant.alice.cert.password    = pw
+        |tenant.alice.connectTimeoutMs = 5000
+        |tenant.alice.readTimeoutMs    = 30000
+        |tenant.bob.cert.type          = pkcs12
+        |tenant.bob.cert.path          = /keys/bob.p12
+        |tenant.bob.cert.password      = pw
+        |""".stripMargin
+
+    val tmp = Files.createTempFile("osci-cfg-", ".properties")
+    Files.writeString(tmp, props)
+    tmp.toFile.deleteOnExit()
+
+    ConfigSource.file[IO](tmp).load.map { m =>
+      val alice = m(TenantId("alice"))
+      assertEquals(alice.connectTimeout, 5.seconds)
+      assertEquals(alice.readTimeout, 30.seconds)
+      val bob = m(TenantId("bob"))
+      assertEquals(bob.connectTimeout, OsciHttpTransport.DefaultConnectTimeout)
+      assertEquals(bob.readTimeout, OsciHttpTransport.DefaultReadTimeout)
+    }
+  }
+
+  test("file raises Config error on a non-numeric timeout") {
+    val props =
+      """tenant.alice.cert.type        = pkcs12
+        |tenant.alice.cert.path        = /keys/alice.p12
+        |tenant.alice.cert.password    = pw
+        |tenant.alice.connectTimeoutMs = fast
+        |""".stripMargin
+
+    val tmp = Files.createTempFile("osci-cfg-", ".properties")
+    Files.writeString(tmp, props)
+    tmp.toFile.deleteOnExit()
+
+    ConfigSource.file[IO](tmp).load.attempt.map {
+      case Left(e: OsciError.Config) =>
+        assert(e.getMessage.contains("connectTimeoutMs"), e.getMessage)
+      case other => fail(s"expected Config error, got $other")
     }
   }
 

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/OsciHttpTransportSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/OsciHttpTransportSpec.scala
@@ -1,0 +1,55 @@
+package de.thatscalaguy.zustellix.osci
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+import java.net.{ServerSocket, SocketTimeoutException, URI}
+import scala.concurrent.duration.*
+
+class OsciHttpTransportSpec extends CatsEffectSuite {
+
+  test("openConnection applies both timeouts") {
+    val t = new OsciHttpTransport(3.seconds, 45.seconds)
+    val c = t.openConnection(new URI("http://localhost:9/osci"))
+    assertEquals(c.getConnectTimeout, 3000)
+    assertEquals(c.getReadTimeout, 45000)
+  }
+
+  test("newInstance carries the timeouts into the per-request clone") {
+    // osci-bibliothek clones the transport per request (OSCIRequest calls
+    // TransportI.newInstance), so a clone without the timeouts would silently
+    // reintroduce the hang.
+    val t = new OsciHttpTransport(3.seconds, 45.seconds)
+    t.newInstance() match {
+      case clone: OsciHttpTransport =>
+        assertEquals(clone.connectTimeout, 3.seconds)
+        assertEquals(clone.readTimeout, 45.seconds)
+      case other => fail(s"expected OsciHttpTransport, got $other")
+    }
+  }
+
+  test("getResponseStream times out on a silent server instead of blocking forever") {
+    IO.blocking {
+      val server = new ServerSocket(0)
+      try {
+        val accepter = new Thread(() => {
+          try {
+            val s = server.accept()
+            Thread.sleep(30000)
+            s.close()
+          } catch { case _: Throwable => () }
+        })
+        accepter.setDaemon(true)
+        accepter.start()
+
+        val t    = new OsciHttpTransport(5.seconds, 250.millis)
+        val body = "<ping/>".getBytes("UTF-8")
+        val out =
+          t.getConnection(new URI(s"http://127.0.0.1:${server.getLocalPort}/osci"), body.length.toLong)
+        out.write(body)
+        out.flush()
+        intercept[SocketTimeoutException](t.getResponseStream.read())
+      } finally server.close()
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2

All OSCI wire operations used osci-bibliothek's sample `HttpTransport`, which sets no connect or read timeout. A stalled intermediary blocked the calling thread forever, and since the bridges are private there was no way to plug in a different transport.

## Changes

**New `OsciHttpTransport`**
- Copy of the sample `HttpTransport` that calls `setConnectTimeout` / `setReadTimeout` on every `HttpURLConnection` it opens.
- The timeouts are carried through `newInstance()`, because osci-bibliothek clones the transport for each request (`OSCIRequest` calls `TransportI.newInstance()`). Without this the clone would open connections without timeouts again.
- A timeout now surfaces as a `SocketTimeoutException`, mapped to `OsciError.OsciTransport` by the bridges.

**Config**
- `OsciConfig` and `OsciMailboxConfig` get `connectTimeout` and `readTimeout` fields. Defaults: 10 s connect, 120 s read. The read timeout bounds each blocking read, not the whole exchange.
- `ConfigSource.file` accepts optional `tenant.<id>.connectTimeoutMs` and `tenant.<id>.readTimeoutMs` keys.

**Pluggable transport**
- `OsciClient.resource` and `OsciMailbox.resource` get overloads that take a `transport: TransportI`. Without it, an `OsciHttpTransport` built from the config timeouts is used. (Overloads instead of a default parameter because Scala forbids default arguments on overloaded methods.)
- `OsciBibBridgeImpl` and `OsciMailboxBridgeImpl` now require the transport instead of defaulting to the sample `HttpTransport`.

## Tests

- `OsciHttpTransportSpec`: timeouts are applied to opened connections; `newInstance()` keeps them; a request against a local server that accepts but never responds fails with `SocketTimeoutException` instead of hanging.
- `ConfigSourceSpec`: the new properties keys are parsed, absent keys fall back to the defaults, non-numeric values raise `OsciError.Config`.