### PR TITLE
osci: record a Laufzettel for failed deliveries

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ libraryDependencies += "de.thatscalaguy" %% "zustellix-utils" % "0.2.0"
 >   duplicate row raises where it previously slipped through, and the
 >   mailbox's `pending` / `fetch` no longer abort on `3800` / `3801`
 >   ("more available than the fetch limit").
+> - `OsciError.OsciResponse` gained a `messageId: Option[String] = None`
+>   field. Construction compiles unchanged; pattern matches that destructure
+>   every field need the new one.
+> - Failed deliveries now record a `Laufzettel` too (see
+>   [Laufzettel](#laufzettel)). Sinks that treated every record as a
+>   delivered message must check `status`: `0xxx` / `3xxx` is delivered,
+>   anything else (a `9xxx` code or an error kind like `OsciTransport`) is a
+>   failure record with empty `rawXml`.
 
 ---
 
@@ -402,8 +410,9 @@ Every outbound operation:
 3. signs the content with the Originator cert, end-to-end encrypts it for the
    addressee (the intermediary stays blind to personal data), and transmits it
    via osci-bibliothek;
-4. records a `Laufzettel` to the configured sink (best-effort — a sink
-   failure never fails the operation).
+4. records a `Laufzettel` to the configured sink — on failure too, so the
+   audit trail is not success-only (best-effort — a sink failure never fails
+   the operation).
 
 > The OSCI bridge requires a PKCS12 `CertSource` (`Pkcs12` or `Pkcs12Bytes`) —
 > neither PEM variant is supported here.
@@ -644,6 +653,21 @@ val toDb: LaufzettelSink[IO] = new LaufzettelSink[IO]:
   def record(tenant: TenantId, l: Laufzettel): IO[Unit] = repo.insert(tenant, l)
 ```
 
+Failed deliveries are recorded too, so the sink sees the complete audit
+trail, not just successes. For a failure Laufzettel:
+
+- `status` is the OSCI feedback code for a `9xxx` response
+  (`OsciError.OsciResponse`) and the error kind otherwise (e.g.
+  `OsciTransport`, `AgsNotInDvdv`);
+- `messageId` is the id issued by `GetMessageId` when the delivery got that
+  far, `""` otherwise;
+- `rawXml` is empty, `warnings` is `Nil`;
+- `recipientUri` is empty when the resolver itself failed (no route exists).
+
+Recording stays best-effort in both directions: a sink failure never fails
+the operation, and a failure record never replaces or swallows the raised
+`OsciError`.
+
 ### Error model
 
 All failures are an `OsciError` (a `RuntimeException`):
@@ -655,7 +679,7 @@ All failures are an `OsciError` (a `RuntimeException`):
 | `RecipientCertMissing` | the service description has no cipher certificate |
 | `ServiceElementMissing`| the `OSCI_ADDRESSEE` / `OSCI_INTERMEDIARY` element is absent |
 | `OsciTransport`        | osci-bibliothek transport / IO failure |
-| `OsciResponse`         | OSCI returned an error (`9xxx`) feedback code |
+| `OsciResponse`         | OSCI returned an error (`9xxx`) feedback code; carries the `messageId` when one was already issued |
 | `NoSuchMessage`        | `fetch(messageId)` found no content for that id |
 | `Certificate`          | cert / key decoding failure |
 | `Config`               | bad configuration (invalid URI, unknown cert type, …) |
@@ -669,7 +693,7 @@ the four-digit code:
 |--------|---------|----------|
 | `0xxx` | success | normal result |
 | `3xxx` | warning — the request **was** executed | tolerated; surfaced as `OsciFeedback(code, text)` in `OsciReceipt.warnings` and `Laufzettel.warnings` |
-| `9xxx` | error — the request was not executed | raised as `OsciError.OsciResponse` |
+| `9xxx` | error — the request was not executed | raised as `OsciError.OsciResponse` (with the intermediary's `messageId` when one was already issued) |
 
 All feedback rows are inspected, so an error behind a per-language duplicate
 row fails too. A common warning is `3802` ("Signatur des Empfängers über die

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciError.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciError.scala
@@ -26,8 +26,16 @@ object OsciError {
   final case class OsciTransport(cause: Throwable)
       extends OsciError("OSCI transport failure", cause)
 
-  final case class OsciResponse(code: String, detail: String)
-      extends OsciError(s"OSCI response error [$code]: $detail")
+  /** OSCI returned an error-class (`9xxx`) feedback code. `messageId` is the
+   *  intermediary-issued message id when one was already assigned before the
+   *  failure (i.e. `GetMessageId` succeeded and the delivery itself failed);
+   *  `None` when the failure happened before an id existed.
+   */
+  final case class OsciResponse(
+      code:      String,
+      detail:    String,
+      messageId: Option[String] = None
+  ) extends OsciError(s"OSCI response error [$code]: $detail")
 
   final case class NoSuchMessage(messageId: String)
       extends OsciError(s"No delivery found for messageId '$messageId'")

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibBridge.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibBridge.scala
@@ -115,7 +115,7 @@ private[osci] final class OsciBibBridgeImpl[F[_]: Sync](
         mediate.addEncryptedData(signedEncryptedPayload(xml, originator, addressee))
 
         val rsp = mediate.send()
-        checkFeedback(rsp.getFeedback)
+        checkFeedback(rsp.getFeedback, Option(msgIdResp.getMessageId))
 
         try new ExitDialog(dialog).send()
         catch case _: Throwable => () // best-effort cleanup
@@ -156,7 +156,7 @@ private[osci] final class OsciBibBridgeImpl[F[_]: Sync](
         storeDelivery.addEncryptedData(signedEncryptedPayload(xml, originator, addressee))
 
         val rsp = storeDelivery.send()
-        checkFeedback(rsp.getFeedback)
+        checkFeedback(rsp.getFeedback, Option(msgIdResp.getMessageId))
 
         try new ExitDialog(dialog).send()
         catch case _: Throwable => () // best-effort cleanup

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupport.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupport.scala
@@ -22,14 +22,16 @@ private[osci] object OsciBibSupport {
   // response missing"), "9" = error (the request was not executed). Warnings
   // must not fail the call; they are surfaced via feedbackWarnings. All rows
   // are scanned — an error in a later row (e.g. behind a per-language
-  // duplicate of row 0) fails too.
-  def checkFeedback(fb: Array[Array[String]]): Unit =
+  // duplicate of row 0) fails too. `messageId` (when already issued at this
+  // point of the dialog) rides along on the raised OsciResponse so callers
+  // can still correlate the failed delivery.
+  def checkFeedback(fb: Array[Array[String]], messageId: Option[String] = None): Unit =
     feedbackRows(fb).foreach { row =>
       if row.length >= 2 && row(1) != null
         && !row(1).startsWith("0") && !row(1).startsWith("3")
       then {
         val detail = if row.length >= 3 then Option(row(2)).getOrElse("") else ""
-        throw OsciError.OsciResponse(row(1), detail)
+        throw OsciError.OsciResponse(row(1), detail, messageId)
       }
     }
 

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
@@ -2,7 +2,16 @@ package de.thatscalaguy.zustellix.osci.internal
 
 import cats.effect.{Clock, Sync}
 import cats.syntax.all.*
-import de.thatscalaguy.zustellix.osci.{Laufzettel, LaufzettelSink, OsciClient, OsciReceipt, TenantId}
+import de.thatscalaguy.zustellix.osci.{
+  Laufzettel,
+  LaufzettelSink,
+  OsciClient,
+  OsciError,
+  OsciReceipt,
+  TenantId
+}
+
+import java.net.URI
 
 private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
     tenantId:  TenantId,
@@ -15,7 +24,9 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
   def request(ags: String, xml: String): F[String] =
     for {
       route  <- resolver.resolve(ags)
+                  .onError { case e => recordFailure(ags, None, e) }
       result <- transport.mediate(route, subject, xml)
+                  .onError { case e => recordFailure(ags, Some(route.addresseeUri), e) }
       now    <- Clock[F].realTimeInstant
       lz      = Laufzettel(
                   messageId    = result.messageId,
@@ -33,7 +44,9 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
   def send(ags: String, xml: String): F[OsciReceipt] =
     for {
       route   <- resolver.resolve(ags)
+                   .onError { case e => recordFailure(ags, None, e) }
       receipt <- transport.store(route, subject, xml)
+                   .onError { case e => recordFailure(ags, Some(route.addresseeUri), e) }
       now     <- Clock[F].realTimeInstant
       lz       = Laufzettel(
                    messageId    = receipt.messageId,
@@ -47,4 +60,38 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
       _       <- sink.record(tenantId, lz).attempt.void
     }
     yield receipt
+
+  /** Failed deliveries leave a Laufzettel too, so the audit trail is not
+   *  success-only: `status` carries the OSCI feedback code for a `9xxx`
+   *  response and the error kind otherwise, `messageId` the id from
+   *  `GetMessageId` when one was issued before the failure ("" otherwise),
+   *  `rawXml` stays empty. `recipientUri` is the resolved addressee URI, or
+   *  empty when the resolver itself failed. Recording is best-effort — the
+   *  original error is re-raised untouched, and a sink failure is swallowed
+   *  like on the success path.
+   */
+  private def recordFailure(ags: String, uri: Option[URI], e: Throwable): F[Unit] =
+    Clock[F].realTimeInstant.flatMap { now =>
+      val lz = Laufzettel(
+        messageId    = failureMessageId(e),
+        timestamp    = now,
+        recipientAgs = ags,
+        recipientUri = uri.getOrElse(URI.create("")),
+        status       = failureStatus(e),
+        rawXml       = ""
+      )
+      sink.record(tenantId, lz).attempt.void
+    }
+
+  private def failureStatus(e: Throwable): String =
+    e match {
+      case OsciError.OsciResponse(code, _, _) => code
+      case other                              => other.getClass.getSimpleName
+    }
+
+  private def failureMessageId(e: Throwable): String =
+    e match {
+      case OsciError.OsciResponse(_, _, Some(id)) => id
+      case _                                      => ""
+    }
 }

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/OsciErrorSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/OsciErrorSpec.scala
@@ -34,6 +34,14 @@ class OsciErrorSpec extends FunSuite {
     assert(e.getMessage.contains("nope"))
   }
 
+  test("OsciResponse carries the messageId when one was already issued") {
+    assertEquals(OsciError.OsciResponse("9000", "boom").messageId, None)
+    assertEquals(
+      OsciError.OsciResponse("9000", "boom", Some("msg-1")).messageId,
+      Some("msg-1")
+    )
+  }
+
   test("NoSuchMessage message includes the message id") {
     val e = OsciError.NoSuchMessage("msg-42")
     assert(e.getMessage.contains("msg-42"))

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupportSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupportSpec.scala
@@ -52,6 +52,21 @@ class OsciBibSupportSpec extends FunSuite {
     }
   }
 
+  test("checkFeedback attaches the messageId to the raised OsciResponse") {
+    val e = intercept[OsciError.OsciResponse] {
+      checkFeedback(Array(Array("de", "9000", "boom")), Some("msg-1"))
+    }
+    assertEquals(e.code, "9000")
+    assertEquals(e.messageId, Some("msg-1"))
+  }
+
+  test("checkFeedback without a messageId raises OsciResponse with messageId None") {
+    val e = intercept[OsciError.OsciResponse] {
+      checkFeedback(Array(Array("de", "9000", "boom")))
+    }
+    assertEquals(e.messageId, None)
+  }
+
   test("checkFeedback: a \"0...\" success code in row 0 does not raise") {
     checkFeedback(Array(Array("de", "0800", "ok"))) // no exception
   }

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
@@ -103,6 +103,97 @@ class OsciClientImplSpec extends CatsEffectSuite {
     }
   }
 
+  test("request: a 9xxx OsciResponse still raises but records a failure Laufzettel") {
+    val err = OsciError.OsciResponse("9000", "boom", Some("msg-9"))
+    Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
+      val impl = new OsciClientImpl[IO](
+        TenantId("alice"),
+        "XMeld",
+        failingTransport(err),
+        fixedResolver(Route),
+        recordingSink(ref)
+      )
+      for {
+        out  <- impl.request(Ags, "<req/>").attempt
+        seen <- ref.get
+      }
+      yield {
+        assertEquals(out, Left(err))
+        assertEquals(seen.size, 1)
+        assertEquals(seen.head.messageId, "msg-9")
+        assertEquals(seen.head.recipientAgs, Ags)
+        assertEquals(seen.head.recipientUri, Route.addresseeUri)
+        assertEquals(seen.head.status, "9000")
+        assertEquals(seen.head.rawXml, "")
+        assertEquals(seen.head.warnings, Nil)
+      }
+    }
+  }
+
+  test("request: a transport failure records a failure Laufzettel with the error kind as status") {
+    val err = OsciError.OsciTransport(new java.io.IOException("net"))
+    Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
+      val impl = new OsciClientImpl[IO](
+        TenantId("alice"),
+        "XMeld",
+        failingTransport(err),
+        fixedResolver(Route),
+        recordingSink(ref)
+      )
+      for {
+        out  <- impl.request(Ags, "<req/>").attempt
+        seen <- ref.get
+      }
+      yield {
+        assertEquals(out, Left(err))
+        assertEquals(seen.size, 1)
+        assertEquals(seen.head.messageId, "")
+        assertEquals(seen.head.status, "OsciTransport")
+        assertEquals(seen.head.rawXml, "")
+      }
+    }
+  }
+
+  test("request: a resolver failure records a failure Laufzettel without a recipient URI") {
+    val err = OsciError.AgsNotInDvdv("nope", "u")
+    Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
+      val impl = new OsciClientImpl[IO](
+        TenantId("alice"),
+        "XMeld",
+        fixedTransport(OsciRawResult("<x/>", "m", "OK")),
+        failingResolver(err),
+        recordingSink(ref)
+      )
+      for {
+        out  <- impl.request("nope", "<x/>").attempt
+        seen <- ref.get
+      }
+      yield {
+        assertEquals(out, Left(err))
+        assertEquals(seen.size, 1)
+        assertEquals(seen.head.recipientAgs, "nope")
+        assertEquals(seen.head.recipientUri, URI.create(""))
+        assertEquals(seen.head.status, "AgsNotInDvdv")
+        assertEquals(seen.head.messageId, "")
+      }
+    }
+  }
+
+  test("request: a sink failure while recording a failure does not mask the original error") {
+    val err  = OsciError.OsciTransport(new java.io.IOException("net"))
+    val impl = new OsciClientImpl[IO](
+      TenantId("alice"),
+      "XMeld",
+      failingTransport(err),
+      fixedResolver(Route),
+      failingSink
+    )
+    impl.request(Ags, "<x/>").attempt.map {
+      case Left(e: OsciError.OsciTransport) => assertEquals(e.getCause.getMessage, "net")
+      case other                            => fail(s"unexpected: $other")
+    }
+  }
+
   test("AgsNotInDvdv from resolver bubbles up") {
     val impl = new OsciClientImpl[IO](
       TenantId("alice"),
@@ -181,6 +272,32 @@ class OsciClientImplSpec extends CatsEffectSuite {
     impl.send(Ags, "<x/>").attempt.map {
       case Left(e: OsciError.OsciTransport) => assertEquals(e.getCause.getMessage, "net")
       case other                            => fail(s"unexpected: $other")
+    }
+  }
+
+  test("send: a failed store records a failure Laufzettel") {
+    val err = OsciError.OsciResponse("9802", "signature invalid", Some("msg-3"))
+    Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
+      val impl = new OsciClientImpl[IO](
+        TenantId("alice"),
+        "XFamilie",
+        failingTransport(err),
+        fixedResolver(Route),
+        recordingSink(ref)
+      )
+      for {
+        out  <- impl.send(Ags, "<req/>").attempt
+        seen <- ref.get
+      }
+      yield {
+        assertEquals(out, Left(err))
+        assertEquals(seen.size, 1)
+        assertEquals(seen.head.messageId, "msg-3")
+        assertEquals(seen.head.recipientAgs, Ags)
+        assertEquals(seen.head.recipientUri, Route.addresseeUri)
+        assertEquals(seen.head.status, "9802")
+        assertEquals(seen.head.rawXml, "")
+      }
     }
   }
 


### PR DESCRIPTION
Closes #4.

`sink.record` only ran after `transport.mediate` / `transport.store` succeeded, so a 9xxx response, a transport failure, or a resolver failure left no audit record. The messageId from `GetMessageId` was also lost, because `OsciError.OsciResponse` had no field for it.

**Changes**

- `OsciClientImpl.request` / `send` now record a Laufzettel on failure too, via `onError` on the resolver and transport steps:
  - `status` is the OSCI feedback code for a `OsciResponse` failure, otherwise the error kind (e.g. `OsciTransport`, `AgsNotInDvdv`)
  - `messageId` is the id from `GetMessageId` when one was issued before the failure, `""` otherwise
  - `rawXml` is empty; `recipientUri` is empty when the resolver itself failed (no route exists yet)
  - recording stays best-effort: a sink failure is swallowed and the original error is re-raised unchanged; each call still records exactly one Laufzettel
- `OsciError.OsciResponse` gained `messageId: Option[String] = None` (breaking, lands before v0.4.0). `OsciBibSupport.checkFeedback` takes the optional messageId and puts it on the raised error; `OsciBibBridge.mediate` / `store` pass the id from `GetMessageId` when checking the delivery response feedback.
- README: documented the failure records in the Laufzettel section and the error tables, and extended the 0.4.x migration note (new field on `OsciResponse`, sinks now also see failure