### PR TITLE
osci: verify content signatures on received messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,44 @@ the intermediary after reception (subject to its retention policy).
 One mailbox can serve several profiles; filter on `PendingDelivery.subject`
 client-side if you need to split them.
 
+### Content signature verification
+
+Received content — synchronous `request` answers and mailbox `fetch`
+deliveries — is checked for the author's content signature
+(Inhaltsdatensignatur) after decryption. The dialog-level checks of
+osci-bibliothek only cover the intermediary envelope signature; the content
+signature is what actually proves the author of the payload.
+
+An **invalid** signature always raises `OsciError.InvalidContentSignature`,
+regardless of configuration. What happens for content that carries **no**
+signature at all is configurable per client/mailbox:
+
+```scala
+val osciConfig = OsciConfig(
+  tenantId          = TenantId("flensburg"),
+  certSource        = Some(cert),
+  contentSignatures = ContentSignaturePolicy.Require   // default: Warn
+)
+
+val mailboxConfig = OsciMailboxConfig(
+  intermedUri        = URI.create("https://intermed.example/osci-manager"),
+  intermedCipherCert = intermedCert,
+  contentSignatures  = ContentSignaturePolicy.Require  // default: Warn
+)
+```
+
+- `ContentSignaturePolicy.Warn` (default): unsigned content is accepted and
+  surfaced as `ContentSignatureStatus.Unsigned` — on `OsciMessage.signature`
+  for mailbox fetches and on `Laufzettel.contentSignature` for `request`
+  responses. Some gateways answer unsigned (the condition feedback code
+  `3802` warns about), which is why this is the default.
+- `ContentSignaturePolicy.Require`: unsigned content raises
+  `OsciError.UnsignedContent`.
+
+Fully verified content yields `ContentSignatureStatus.Valid`. The check
+verifies the signatures cryptographically against the certificates embedded
+in the message; certificate chain/trust validation stays with the caller.
+
 ### HTTP timeouts and custom transport
 
 All wire operations go through an `OsciHttpTransport` — a drop-in for
@@ -605,6 +643,7 @@ tenant.flensburg.serviceUri       = http://www.osci.de/xmeld2605/xmeld2605Person
 tenant.flensburg.subject          = XMeld
 tenant.flensburg.connectTimeoutMs = 5000
 tenant.flensburg.readTimeoutMs    = 60000
+tenant.flensburg.contentSignatures = require
 
 tenant.kiel.cert.type     = pem
 tenant.kiel.cert.path     = /secrets/kiel-cert.pem
@@ -614,7 +653,8 @@ tenant.kiel.cert.password = optional-key-password
 
 (`serviceUri` and `subject` are optional and default to the XMeld
 Personensuche WSDL and `XMeld`; `connectTimeoutMs` / `readTimeoutMs` are
-optional and default to 10 s / 120 s.)
+optional and default to 10 s / 120 s; `contentSignatures` is optional —
+`require` or `warn`, default `warn`.)
 
 Multi-tenant mailboxes are simply multiple `OsciMailbox.resource` calls — one
 per tenant cert/intermediary.
@@ -640,9 +680,9 @@ OsciMailbox.resource[IO](mailboxConfig, certManager, alias)
 ### Laufzettel
 
 Each `request` / `send` produces a `Laufzettel(messageId, timestamp,
-recipientAgs, recipientUri, status, rawXml, warnings)` handed to a
-`LaufzettelSink[F]` (for `send`, `rawXml` is empty — there is no response
-payload at store time):
+recipientAgs, recipientUri, status, rawXml, warnings, contentSignature)`
+handed to a `LaufzettelSink[F]` (for `send`, `rawXml` is empty and
+`contentSignature` is `None` — there is no response payload at store time):
 
 ```scala
 LaufzettelSink.console[IO]   // prints a one-line summary
@@ -681,6 +721,8 @@ All failures are an `OsciError` (a `RuntimeException`):
 | `OsciTransport`        | osci-bibliothek transport / IO failure |
 | `OsciResponse`         | OSCI returned an error (`9xxx`) feedback code; carries the `messageId` when one was already issued |
 | `NoSuchMessage`        | `fetch(messageId)` found no content for that id |
+| `UnsignedContent`      | received content carries no content signature and `contentSignatures = Require` |
+| `InvalidContentSignature` | the content signature on received content failed verification (raised regardless of policy) |
 | `Certificate`          | cert / key decoding failure |
 | `Config`               | bad configuration (invalid URI, unknown cert type, …) |
 
@@ -700,7 +742,9 @@ row fails too. A common warning is `3802` ("Signatur des Empfängers über die
 Annahme- bzw. Bearbeitungsantwort fehlt"): the recipient's gateway answered
 without signing its response. The response payload is still delivered — only
 the cryptographic proof over the recipient's answer is missing, which the
-`warnings` list lets you log or escalate per your own policy.
+`warnings` list lets you log or escalate per your own policy. The author's
+signature over the content itself is verified separately — see
+[Content signature verification](#content-signature-verification).
 
 ---
 

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/ContentSignature.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/ContentSignature.scala
@@ -1,0 +1,40 @@
+package de.thatscalaguy.zustellix.osci
+
+/** How strictly the author's content signature (Inhaltsdatensignatur) on
+ *  received messages is enforced. The dialog-level checks of osci-bibliothek
+ *  only cover the intermediary envelope signature — the content signature
+ *  inside the (decrypted) `ContentContainer` is what proves the author, so it
+ *  is verified separately after decryption.
+ *
+ *  An *invalid* signature always raises
+ *  [[OsciError.InvalidContentSignature]] — the policy only decides what
+ *  happens when content carries no signature at all. Some gateways answer
+ *  unsigned (the condition OSCI feedback code `3802` warns about), which is
+ *  why [[ContentSignaturePolicy.Warn]] is the default.
+ */
+enum ContentSignaturePolicy {
+
+  /** Unsigned content raises [[OsciError.UnsignedContent]]. */
+  case Require
+
+  /** Unsigned content is accepted and surfaced as
+   *  [[ContentSignatureStatus.Unsigned]] (on [[OsciMessage.signature]] and
+   *  [[Laufzettel.contentSignature]]).
+   */
+  case Warn
+}
+
+/** Outcome of verifying the content signature of received content. An
+ *  invalid signature never appears here — it raises
+ *  [[OsciError.InvalidContentSignature]] regardless of policy.
+ */
+enum ContentSignatureStatus {
+
+  /** The content was signed and every signature verified. */
+  case Valid
+
+  /** The content carried no signature (tolerated under
+   *  [[ContentSignaturePolicy.Warn]]).
+   */
+  case Unsigned
+}

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/Laufzettel.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/Laufzettel.scala
@@ -3,6 +3,10 @@ package de.thatscalaguy.zustellix.osci
 import java.net.URI
 import java.time.Instant
 
+/** `contentSignature` is the verified status of the author's content
+ *  signature over `rawXml` — `None` when there was no response content to
+ *  check (async `send`, failures).
+ */
 final case class Laufzettel(
     messageId:    String,
     timestamp:    Instant,
@@ -10,5 +14,6 @@ final case class Laufzettel(
     recipientUri: URI,
     status:       String,
     rawXml:       String,
-    warnings:     List[OsciFeedback] = Nil
+    warnings:     List[OsciFeedback] = Nil,
+    contentSignature: Option[ContentSignatureStatus] = None
 )

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciClient.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciClient.scala
@@ -62,10 +62,11 @@ object OsciClient {
         "OsciConfig.certSource is not set — set it, or use the CertManager/CertAlias overload"
       )
     )
-    Resource.eval(certSource).flatMap(internal.OsciBibBridge.resource[F](_, transport)).map {
-      bridge =>
+    Resource.eval(certSource)
+      .flatMap(internal.OsciBibBridge.resource[F](_, transport, config.contentSignatures))
+      .map { bridge =>
         new internal.OsciClientImpl[F](config.tenantId, config.subject, bridge, resolver, sink)
-    }
+      }
   }
 
   /** Build an OSCI/XMeld client whose Originator (Autor) signing + decryption
@@ -96,7 +97,7 @@ object OsciClient {
     val resolver = internal.AgsResolver[F](dvdv, config)
     for {
       cred   <- Resource.eval(certs.resolve(alias))
-      bridge <- internal.OsciBibBridge.resource[F](cred, transport)
+      bridge <- internal.OsciBibBridge.resource[F](cred, transport, config.contentSignatures)
     } yield new internal.OsciClientImpl[F](
       TenantId(alias.value), config.subject, bridge, resolver, sink
     )

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciConfig.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciConfig.scala
@@ -14,6 +14,10 @@ import scala.concurrent.duration.FiniteDuration
  *  `connectTimeout` / `readTimeout` bound the default [[OsciHttpTransport]]'s
  *  `HttpURLConnection`s; they are ignored when a custom transport is passed
  *  to `OsciClient.resource`.
+ *
+ *  `contentSignatures` sets how strictly the author's content signature on
+ *  received response content (synchronous `request` answers) is enforced —
+ *  see [[ContentSignaturePolicy]].
  */
 final case class OsciConfig(
     tenantId: TenantId,
@@ -25,7 +29,8 @@ final case class OsciConfig(
     serviceUri: String = OsciConfig.DefaultXMeldServiceUri,
     subject: String = OsciConfig.DefaultSubject,
     connectTimeout: FiniteDuration = OsciHttpTransport.DefaultConnectTimeout,
-    readTimeout: FiniteDuration = OsciHttpTransport.DefaultReadTimeout
+    readTimeout: FiniteDuration = OsciHttpTransport.DefaultReadTimeout,
+    contentSignatures: ContentSignaturePolicy = ContentSignaturePolicy.Warn
 )
 
 object OsciConfig {

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciError.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciError.scala
@@ -40,6 +40,22 @@ object OsciError {
   final case class NoSuchMessage(messageId: String)
       extends OsciError(s"No delivery found for messageId '$messageId'")
 
+  /** Received content carries no author signature and the policy is
+   *  [[ContentSignaturePolicy.Require]]. `messageId` identifies the affected
+   *  message when one is known at that point.
+   */
+  final case class UnsignedContent(messageId: Option[String] = None)
+      extends OsciError("OSCI content is not signed but the policy requires a content signature")
+
+  /** The author's content signature on received content failed verification.
+   *  Raised regardless of the configured [[ContentSignaturePolicy]] — a
+   *  broken signature is never tolerated.
+   */
+  final case class InvalidContentSignature(
+      messageId: Option[String] = None,
+      cause:     Throwable | Null = null
+  ) extends OsciError("OSCI content signature verification failed", cause)
+
   final case class Certificate(cause: Throwable)
       extends OsciError("Certificate / key error", cause)
 

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMailboxConfig.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMailboxConfig.scala
@@ -19,11 +19,15 @@ import scala.concurrent.duration.FiniteDuration
  *  @param readTimeout        HTTP read timeout of the default
  *                            [[OsciHttpTransport]]; ignored when a custom
  *                            transport is passed to `OsciMailbox.resource`
+ *  @param contentSignatures  how strictly the author's content signature on
+ *                            fetched deliveries is enforced (see
+ *                            [[ContentSignaturePolicy]])
  */
 final case class OsciMailboxConfig(
     intermedUri:        URI,
     intermedCipherCert: X509Certificate,
     fetchLimit:         Long = 100,
     connectTimeout:     FiniteDuration = OsciHttpTransport.DefaultConnectTimeout,
-    readTimeout:        FiniteDuration = OsciHttpTransport.DefaultReadTimeout
+    readTimeout:        FiniteDuration = OsciHttpTransport.DefaultReadTimeout,
+    contentSignatures:  ContentSignaturePolicy = ContentSignaturePolicy.Warn
 )

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMessage.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMessage.scala
@@ -13,11 +13,16 @@ final case class PendingDelivery(
 
 /** A fetched delivery. `reception` is the intermediary's reception entry on
  *  the process card — the acknowledgement mark (see [[OsciMailbox]]).
+ *  `signature` is the verified status of the author's content signature over
+ *  `xml`; it is [[ContentSignatureStatus.Unsigned]] only under
+ *  [[ContentSignaturePolicy.Warn]] — an invalid signature never yields a
+ *  message but raises [[OsciError.InvalidContentSignature]].
  */
 final case class OsciMessage(
     messageId: String,
     subject:   Option[String],
     xml:       String,
     creation:  Option[Instant],
-    reception: Option[Instant]
+    reception: Option[Instant],
+    signature: ContentSignatureStatus
 )

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/FileConfigSource.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/FileConfigSource.scala
@@ -21,6 +21,7 @@ import scala.jdk.CollectionConverters.*
  *   tenant.<id>.subject                = <osci subject>      (optional)
  *   tenant.<id>.connectTimeoutMs       = <millis>            (optional)
  *   tenant.<id>.readTimeoutMs          = <millis>            (optional)
+ *   tenant.<id>.contentSignatures      = require | warn      (optional, default warn)
  * }}}
  *
  *  The intermediary is no longer configured here — it is resolved per send
@@ -76,13 +77,26 @@ private[osci] final class FileConfigSource[F[_]: Sync](path: Path) extends Confi
         )
       }
 
+    val contentSignatures =
+      kv.get("contentSignatures").fold(ContentSignaturePolicy.Warn) { v =>
+        v.trim.toLowerCase match {
+          case "require" => ContentSignaturePolicy.Require
+          case "warn"    => ContentSignaturePolicy.Warn
+          case other =>
+            throw OsciError.Config(
+              s"tenant.$id.contentSignatures must be 'require' or 'warn', got '$other'"
+            )
+        }
+      }
+
     OsciConfig(
       tenantId       = TenantId(id),
       certSource     = Some(certSource),
       serviceUri     = kv.getOrElse("serviceUri", OsciConfig.DefaultXMeldServiceUri),
       subject        = kv.getOrElse("subject", OsciConfig.DefaultSubject),
       connectTimeout = timeoutMs("connectTimeoutMs", OsciHttpTransport.DefaultConnectTimeout),
-      readTimeout    = timeoutMs("readTimeoutMs", OsciHttpTransport.DefaultReadTimeout)
+      readTimeout    = timeoutMs("readTimeoutMs", OsciHttpTransport.DefaultReadTimeout),
+      contentSignatures = contentSignatures
     )
   }
 }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibBridge.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibBridge.scala
@@ -2,7 +2,7 @@ package de.thatscalaguy.zustellix.osci.internal
 
 import cats.effect.{Resource, Sync}
 import de.thatscalaguy.zustellix.utils.cert.{CertCredential, CertSource}
-import de.thatscalaguy.zustellix.osci.{OsciError, OsciReceipt}
+import de.thatscalaguy.zustellix.osci.{ContentSignaturePolicy, OsciError, OsciReceipt}
 
 import de.osci.osci12.common.DialogHandler
 import de.osci.osci12.extinterfaces.TransportI
@@ -25,18 +25,22 @@ private[osci] object OsciBibBridge {
 
   def resource[F[_]: Sync](
       certSource: CertSource,
-      transport:  TransportI
+      transport:  TransportI,
+      contentSignatures: ContentSignaturePolicy
   ): Resource[F, OsciTransport[F]] =
-    Resource.eval(originator[F](certSource)).map(new OsciBibBridgeImpl[F](_, transport))
+    Resource.eval(originator[F](certSource))
+      .map(new OsciBibBridgeImpl[F](_, transport, contentSignatures))
 
   /** Alias-keyed path: the same PKCS12 the DVDV client uses, supplied by the
    *  shared [[de.thatscalaguy.zustellix.utils.cert.CertManager]] as bytes.
    */
   def resource[F[_]: Sync](
       cred:      CertCredential,
-      transport: TransportI
+      transport: TransportI,
+      contentSignatures: ContentSignaturePolicy
   ): Resource[F, OsciTransport[F]] =
-    Resource.eval(originator[F](cred)).map(new OsciBibBridgeImpl[F](_, transport))
+    Resource.eval(originator[F](cred))
+      .map(new OsciBibBridgeImpl[F](_, transport, contentSignatures))
 
   /** Our own OSCI role: signer + decrypter from the tenant's PKCS12. Also
    *  used by the mailbox bridge, where the same role fetches and decrypts
@@ -89,7 +93,8 @@ private[osci] object OsciBibBridge {
 
 private[osci] final class OsciBibBridgeImpl[F[_]: Sync](
     originator: Originator,
-    transport: TransportI
+    transport: TransportI,
+    contentSignatures: ContentSignaturePolicy
 ) extends OsciTransport[F] {
 
   import OsciBibSupport.*
@@ -120,15 +125,24 @@ private[osci] final class OsciBibBridgeImpl[F[_]: Sync](
         try new ExitDialog(dialog).send()
         catch case _: Throwable => () // best-effort cleanup
 
+        // The synchronous answer comes back encrypted to our cipher cert
+        // (the OSCI roles swap: our Originator becomes the response's
+        // Addressee), so extractVerifiedXml decrypts with our own role and
+        // then checks the author's content signature.
+        val verified = extractVerifiedXml(
+          rsp.getContentContainer,
+          rsp.getEncryptedData,
+          originator,
+          contentSignatures,
+          Option(msgIdResp.getMessageId)
+        )
+
         OsciRawResult(
-          // The synchronous answer comes back encrypted to our cipher cert
-          // (the OSCI roles swap: our Originator becomes the response's
-          // Addressee), so extractXml decrypts with our own role.
-          responseXml = extractXml(rsp.getContentContainer, rsp.getEncryptedData, originator)
-            .getOrElse(""),
-          messageId = msgIdResp.getMessageId,
-          status    = topFeedbackCode(rsp.getFeedback),
-          warnings  = feedbackWarnings(rsp.getFeedback)
+          responseXml = verified.map(_._1).getOrElse(""),
+          messageId   = msgIdResp.getMessageId,
+          status      = topFeedbackCode(rsp.getFeedback),
+          warnings    = feedbackWarnings(rsp.getFeedback),
+          signature   = verified.map(_._2)
         )
       }
       catch {

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupport.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupport.scala
@@ -1,6 +1,11 @@
 package de.thatscalaguy.zustellix.osci.internal
 
-import de.thatscalaguy.zustellix.osci.{OsciError, OsciFeedback}
+import de.thatscalaguy.zustellix.osci.{
+  ContentSignaturePolicy,
+  ContentSignatureStatus,
+  OsciError,
+  OsciFeedback
+}
 
 import de.osci.osci12.OSCIException
 import de.osci.osci12.messageparts.{Content, ContentContainer, EncryptedDataOSCI, Timestamp}
@@ -56,25 +61,61 @@ private[osci] object OsciBibSupport {
     Option(fb).map(_.toList).getOrElse(Nil).filter(_ != null)
 
   def firstContentData(ccs: List[ContentContainer]): Option[String] =
-    ccs.iterator
-      .flatMap(cc => Option(cc.getContents).map(_.toList).getOrElse(Nil))
-      .map(_.getContentData)
-      .find(s => s != null && s.nonEmpty)
+    firstContent(ccs).map(_._2)
 
-  /** Content data of a received message: plaintext containers are tried
-   *  first, then the `EncryptedDataOSCI` entries are decrypted with
-   *  `decryptWith` (the role carrying our own Decrypter — payloads addressed
-   *  to us are encrypted to our cipher cert).
+  /** The first non-empty content payload, together with the container that
+   *  carries it — the container is what the content signature covers.
    */
-  def extractXml(
+  private def firstContent(ccs: List[ContentContainer]): Option[(ContentContainer, String)] =
+    ccs.iterator
+      .flatMap { cc =>
+        Option(cc.getContents).map(_.toList).getOrElse(Nil).map(c => (cc, c.getContentData))
+      }
+      .find { case (_, s) => s != null && s.nonEmpty }
+
+  /** Content data of a received message, with its content signature verified:
+   *  plaintext containers are tried first, then the `EncryptedDataOSCI`
+   *  entries are decrypted with `decryptWith` (the role carrying our own
+   *  Decrypter — payloads addressed to us are encrypted to our cipher cert).
+   *  The container the returned xml came from is checked via
+   *  [[verifyContentSignature]] — the dialog default only verifies the
+   *  intermediary envelope signature, not the author's content signature.
+   */
+  def extractVerifiedXml(
       plain:       Array[ContentContainer],
       encrypted:   Array[EncryptedDataOSCI],
-      decryptWith: Role
-  ): Option[String] =
-    firstContentData(Option(plain).map(_.toList).getOrElse(Nil)).orElse {
-      val enc       = Option(encrypted).map(_.toList).getOrElse(Nil)
-      val decrypted = enc.flatMap(e => Option(e.decrypt(decryptWith)))
-      firstContentData(decrypted)
+      decryptWith: Role,
+      policy:      ContentSignaturePolicy,
+      messageId:   Option[String]
+  ): Option[(String, ContentSignatureStatus)] =
+    firstContent(Option(plain).map(_.toList).getOrElse(Nil))
+      .orElse {
+        val enc = Option(encrypted).map(_.toList).getOrElse(Nil)
+        firstContent(enc.flatMap(e => Option(e.decrypt(decryptWith))))
+      }
+      .map { case (cc, xml) => (xml, verifyContentSignature(cc, policy, messageId)) }
+
+  /** `ContentContainer.checkAllSignatures()` over the container the returned
+   *  content came from. An invalid (or uncheckable) signature always raises;
+   *  the policy only decides whether *unsigned* content raises or is
+   *  surfaced as [[ContentSignatureStatus.Unsigned]].
+   */
+  def verifyContentSignature(
+      cc:        ContentContainer,
+      policy:    ContentSignaturePolicy,
+      messageId: Option[String]
+  ): ContentSignatureStatus =
+    if Option(cc.getSigners).forall(_.isEmpty) then
+      policy match {
+        case ContentSignaturePolicy.Require => throw OsciError.UnsignedContent(messageId)
+        case ContentSignaturePolicy.Warn    => ContentSignatureStatus.Unsigned
+      }
+    else {
+      val ok =
+        try cc.checkAllSignatures()
+        catch case e: Exception => throw OsciError.InvalidContentSignature(messageId, e)
+      if !ok then throw OsciError.InvalidContentSignature(messageId)
+      ContentSignatureStatus.Valid
     }
 
   /** OSCI content-data profile (XMeld, XFamilie, ...): the Inhaltsdaten must

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
@@ -35,7 +35,8 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
                   recipientUri = route.addresseeUri,
                   status       = result.status,
                   rawXml       = result.responseXml,
-                  warnings     = result.warnings
+                  warnings     = result.warnings,
+                  contentSignature = result.signature
                 )
       _      <- sink.record(tenantId, lz).attempt.void
     }
@@ -91,7 +92,9 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
 
   private def failureMessageId(e: Throwable): String =
     e match {
-      case OsciError.OsciResponse(_, _, Some(id)) => id
-      case _                                      => ""
+      case OsciError.OsciResponse(_, _, Some(id))         => id
+      case OsciError.UnsignedContent(Some(id))            => id
+      case OsciError.InvalidContentSignature(Some(id), _) => id
+      case _                                              => ""
     }
 }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciMailboxBridge.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciMailboxBridge.scala
@@ -66,15 +66,21 @@ private[osci] final class OsciMailboxBridgeImpl[F[_]: Sync](
         val rsp = fd.send()
         checkFeedback(rsp.getFeedback)
 
-        val xml = extractXml(rsp.getContentContainer, rsp.getEncryptedData, originator)
-          .getOrElse(throw OsciError.NoSuchMessage(messageId))
+        val (xml, signature) = extractVerifiedXml(
+          rsp.getContentContainer,
+          rsp.getEncryptedData,
+          originator,
+          config.contentSignatures,
+          Some(messageId)
+        ).getOrElse(throw OsciError.NoSuchMessage(messageId))
 
         OsciMessage(
           messageId = Option(rsp.getMessageId).getOrElse(messageId),
           subject   = Option(rsp.getSubject),
           xml       = xml,
           creation  = parseTimestamp(rsp.getTimestampCreation),
-          reception = Option(rsp.getProcessCardBundle).flatMap(pc => parseTimestamp(pc.getReception))
+          reception = Option(rsp.getProcessCardBundle).flatMap(pc => parseTimestamp(pc.getReception)),
+          signature = signature
         )
       }
       catch {

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciTransport.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciTransport.scala
@@ -1,6 +1,6 @@
 package de.thatscalaguy.zustellix.osci.internal
 
-import de.thatscalaguy.zustellix.osci.{OsciFeedback, OsciReceipt}
+import de.thatscalaguy.zustellix.osci.{ContentSignatureStatus, OsciFeedback, OsciReceipt}
 
 import java.net.URI
 import java.security.cert.X509Certificate
@@ -22,12 +22,16 @@ final case class OsciRoute(
     intermedCipher:  X509Certificate
 )
 
-/** Raw OSCI transmission result, before being mapped into a domain Laufzettel. */
+/** Raw OSCI transmission result, before being mapped into a domain Laufzettel.
+ *  `signature` is the verified content-signature status of `responseXml`
+ *  (`None` when the response carried no content to check).
+ */
 final case class OsciRawResult(
     responseXml: String,
     messageId:   String,
     status:      String,
-    warnings:    List[OsciFeedback] = Nil
+    warnings:    List[OsciFeedback] = Nil,
+    signature:   Option[ContentSignatureStatus] = None
 )
 
 /** Narrow mockable seam over the Governikus osci-bibliothek Java library for

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/ConfigSourceSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/ConfigSourceSpec.scala
@@ -114,6 +114,46 @@ class ConfigSourceSpec extends CatsEffectSuite {
     }
   }
 
+  test("file parses optional contentSignatures and defaults it to Warn when absent") {
+    val props =
+      """tenant.alice.cert.type         = pkcs12
+        |tenant.alice.cert.path         = /keys/alice.p12
+        |tenant.alice.cert.password     = pw
+        |tenant.alice.contentSignatures = require
+        |tenant.bob.cert.type           = pkcs12
+        |tenant.bob.cert.path           = /keys/bob.p12
+        |tenant.bob.cert.password       = pw
+        |""".stripMargin
+
+    val tmp = Files.createTempFile("osci-cfg-", ".properties")
+    Files.writeString(tmp, props)
+    tmp.toFile.deleteOnExit()
+
+    ConfigSource.file[IO](tmp).load.map { m =>
+      assertEquals(m(TenantId("alice")).contentSignatures, ContentSignaturePolicy.Require)
+      assertEquals(m(TenantId("bob")).contentSignatures, ContentSignaturePolicy.Warn)
+    }
+  }
+
+  test("file raises Config error on an unknown contentSignatures value") {
+    val props =
+      """tenant.alice.cert.type         = pkcs12
+        |tenant.alice.cert.path         = /keys/alice.p12
+        |tenant.alice.cert.password     = pw
+        |tenant.alice.contentSignatures = strict
+        |""".stripMargin
+
+    val tmp = Files.createTempFile("osci-cfg-", ".properties")
+    Files.writeString(tmp, props)
+    tmp.toFile.deleteOnExit()
+
+    ConfigSource.file[IO](tmp).load.attempt.map {
+      case Left(e: OsciError.Config) =>
+        assert(e.getMessage.contains("contentSignatures"), e.getMessage)
+      case other => fail(s"expected Config error, got $other")
+    }
+  }
+
   test("file raises Config error on missing required cert.path") {
     val props =
       """tenant.broken.cert.type     = pkcs12

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/OsciErrorSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/OsciErrorSpec.scala
@@ -47,6 +47,18 @@ class OsciErrorSpec extends FunSuite {
     assert(e.getMessage.contains("msg-42"))
   }
 
+  test("UnsignedContent carries the messageId when one is known") {
+    assertEquals(OsciError.UnsignedContent().messageId, None)
+    assertEquals(OsciError.UnsignedContent(Some("msg-1")).messageId, Some("msg-1"))
+  }
+
+  test("InvalidContentSignature preserves the cause") {
+    val cause = new Exception("digest mismatch")
+    val e     = OsciError.InvalidContentSignature(Some("msg-1"), cause)
+    assertEquals(e.getCause, cause)
+    assertEquals(e.messageId, Some("msg-1"))
+  }
+
   test("All variants are OsciError subtypes") {
     val errs: List[OsciError] = List(
       OsciError.UnknownTenant(TenantId("x")),
@@ -55,6 +67,8 @@ class OsciErrorSpec extends FunSuite {
       OsciError.OsciTransport(new IOException("x")),
       OsciError.OsciResponse("c", "d"),
       OsciError.NoSuchMessage("m"),
+      OsciError.UnsignedContent(),
+      OsciError.InvalidContentSignature(),
       OsciError.Certificate(new Exception("c")),
       OsciError.Config("r")
     )

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupportSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibSupportSpec.scala
@@ -1,10 +1,16 @@
 package de.thatscalaguy.zustellix.osci.internal
 
-import de.thatscalaguy.zustellix.osci.{OsciError, OsciFeedback}
+import de.thatscalaguy.zustellix.osci.{
+  ContentSignaturePolicy,
+  ContentSignatureStatus,
+  OsciError,
+  OsciFeedback
+}
 import munit.FunSuite
 
 import de.osci.osci12.messageparts.{Content, ContentContainer, EncryptedDataOSCI, Timestamp}
 import de.osci.osci12.roles.Originator
+import de.osci.osci12.samples.impl.crypto.{PKCS12Decrypter, PKCS12Signer}
 
 import java.math.BigInteger
 import java.security.cert.X509Certificate
@@ -41,6 +47,16 @@ class OsciBibSupportSpec extends FunSuite {
   }
 
   private lazy val role = new Originator(cert, cert)
+
+  /** A signing-capable role over the test PKCS12 (same fixture the bridges
+   *  use in production) — needed to actually sign / decrypt containers.
+   */
+  private lazy val signingRole: Originator = {
+    java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider())
+    def p12 = getClass.getClassLoader.getResourceAsStream("test-cert.p12")
+    new Originator(new PKCS12Signer(p12, "test"), new PKCS12Decrypter(p12, "test"))
+  }
+
 
   // OSCI feedback rows are [lang, code, text]. OSCI 1.2 code classes:
   // "0xxx" = success, "3xxx" = warning (request executed), "9xxx" = error.
@@ -162,20 +178,99 @@ class OsciBibSupportSpec extends FunSuite {
     assertEquals(firstContentData(List(new ContentContainer())), None)
   }
 
-  test("extractXml prefers a plaintext container and never touches the encrypted entries") {
+  test("extractVerifiedXml prefers a plaintext container and never touches the encrypted entries") {
     val cc = new ContentContainer()
     cc.addContent(new Content("<xml>plain</xml>"))
     // A decrypt attempt on this bogus entry would throw — proving it is not touched.
-    val out = extractXml(Array(cc), Array.empty[EncryptedDataOSCI], role)
-    assertEquals(out, Some("<xml>plain</xml>"))
+    val out = extractVerifiedXml(
+      Array(cc), Array.empty[EncryptedDataOSCI], role, ContentSignaturePolicy.Warn, None
+    )
+    assertEquals(out, Some(("<xml>plain</xml>", ContentSignatureStatus.Unsigned)))
   }
 
-  test("extractXml tolerates null arrays and yields None") {
-    assertEquals(extractXml(null, null, role), None)
+  test("extractVerifiedXml tolerates null arrays and yields None") {
+    assertEquals(extractVerifiedXml(null, null, role, ContentSignaturePolicy.Require, None), None)
   }
 
-  test("extractXml yields None when nothing carries content") {
-    assertEquals(extractXml(Array(new ContentContainer()), Array.empty[EncryptedDataOSCI], role), None)
+  test("extractVerifiedXml yields None when nothing carries content") {
+    assertEquals(
+      extractVerifiedXml(
+        Array(new ContentContainer()), Array.empty[EncryptedDataOSCI], role,
+        ContentSignaturePolicy.Require, None
+      ),
+      None
+    )
+  }
+
+  test("extractVerifiedXml: a signed container verifies as Valid under Require") {
+    val cc = new ContentContainer()
+    cc.addContent(new Content("<xml>signed</xml>"))
+    cc.sign(signingRole)
+    val out = extractVerifiedXml(
+      Array(cc), Array.empty[EncryptedDataOSCI], signingRole, ContentSignaturePolicy.Require, None
+    )
+    assertEquals(out, Some(("<xml>signed</xml>", ContentSignatureStatus.Valid)))
+  }
+
+  test("extractVerifiedXml: unsigned content under Require raises UnsignedContent with the messageId") {
+    val cc = new ContentContainer()
+    cc.addContent(new Content("<xml>plain</xml>"))
+    val e = intercept[OsciError.UnsignedContent] {
+      extractVerifiedXml(
+        Array(cc), Array.empty[EncryptedDataOSCI], role,
+        ContentSignaturePolicy.Require, Some("msg-7")
+      )
+    }
+    assertEquals(e.messageId, Some("msg-7"))
+  }
+
+  test("extractVerifiedXml verifies the signature of a decrypted container") {
+    // Decrypting a self-built EncryptedDataOSCI needs a wire roundtrip (the
+    // encrypted keys only land in the EncryptedData on serialization), so
+    // decrypt is stubbed to return the signed container — what matters here
+    // is that the encrypted branch runs the same verification.
+    val signed = new ContentContainer()
+    signed.addContent(new Content("<xml>e2e</xml>"))
+    signed.sign(signingRole)
+    val enc = new EncryptedDataOSCI(new ContentContainer()) {
+      override def decrypt(role: de.osci.osci12.roles.Role): ContentContainer = signed
+    }
+    val out = extractVerifiedXml(
+      null, Array[EncryptedDataOSCI](enc), signingRole, ContentSignaturePolicy.Require, None
+    )
+    assertEquals(out, Some(("<xml>e2e</xml>", ContentSignatureStatus.Valid)))
+  }
+
+  test("extractVerifiedXml: a corrupted signature raises InvalidContentSignature") {
+    val cc = new ContentContainer()
+    cc.addContent(new Content("<xml>original</xml>"))
+    cc.sign(signingRole)
+    val sig = cc.getSignatures()(0)
+    sig.signatureValue(0) = (sig.signatureValue(0) ^ 0xff).toByte
+    val e = intercept[OsciError.InvalidContentSignature] {
+      extractVerifiedXml(
+        Array(cc), Array.empty[EncryptedDataOSCI], signingRole,
+        ContentSignaturePolicy.Warn, Some("msg-8")
+      )
+    }
+    assertEquals(e.messageId, Some("msg-8"))
+  }
+
+  test("verifyContentSignature: unsigned + Warn yields Unsigned, signed yields Valid") {
+    val unsigned = new ContentContainer()
+    unsigned.addContent(new Content("<a/>"))
+    assertEquals(
+      verifyContentSignature(unsigned, ContentSignaturePolicy.Warn, None),
+      ContentSignatureStatus.Unsigned
+    )
+
+    val signed = new ContentContainer()
+    signed.addContent(new Content("<a/>"))
+    signed.sign(signingRole)
+    assertEquals(
+      verifyContentSignature(signed, ContentSignaturePolicy.Require, None),
+      ContentSignatureStatus.Valid
+    )
   }
 
   test("parseInstant handles the offset xsd:dateTime form") {

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
@@ -103,6 +103,49 @@ class OsciClientImplSpec extends CatsEffectSuite {
     }
   }
 
+  test("the content-signature status from the transport lands on the Laufzettel") {
+    val raw = OsciRawResult(
+      "<resp/>", "msg-1", "0800", Nil, Some(ContentSignatureStatus.Unsigned)
+    )
+    Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
+      val impl = new OsciClientImpl[IO](
+        TenantId("alice"),
+        "XMeld",
+        fixedTransport(raw),
+        fixedResolver(Route),
+        recordingSink(ref)
+      )
+      for {
+        _    <- impl.request(Ags, "<req/>")
+        seen <- ref.get
+      }
+      yield assertEquals(seen.head.contentSignature, Some(ContentSignatureStatus.Unsigned))
+    }
+  }
+
+  test("request: an UnsignedContent failure records a failure Laufzettel with its messageId") {
+    val err = OsciError.UnsignedContent(Some("msg-u"))
+    Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
+      val impl = new OsciClientImpl[IO](
+        TenantId("alice"),
+        "XMeld",
+        failingTransport(err),
+        fixedResolver(Route),
+        recordingSink(ref)
+      )
+      for {
+        out  <- impl.request(Ags, "<req/>").attempt
+        seen <- ref.get
+      }
+      yield {
+        assertEquals(out, Left(err))
+        assertEquals(seen.head.messageId, "msg-u")
+        assertEquals(seen.head.status, "UnsignedContent")
+        assertEquals(seen.head.contentSignature, None)
+      }
+    }
+  }
+
   test("request: a 9xxx OsciResponse still raises but records a failure Laufzettel") {
     val err = OsciError.OsciResponse("9000", "boom", Some("msg-9"))
     Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>


### PR DESCRIPTION
Fixes #5

Received OSCI payloads were decrypted but the author's content signature was never checked. The dialog-level checks only cover the intermediary envelope signature, so unsigned or re-signed content was returned as trusted XML. This affected mediate responses and mailbox fetches.

Both receive paths now call `ContentContainer.checkAllSignatures()` on the container the returned content came from, after decryption.

**Behaviour**

- An invalid signature always raises the new `OsciError.InvalidContentSignature`, no matter how the client is configured. A broken signature is never tolerated.
- Unsigned content is handled by the new `ContentSignaturePolicy` setting on `OsciConfig` and `OsciMailboxConfig`:
  - `Warn` (default): the content is accepted and flagged as `ContentSignatureStatus.Unsigned`. This is the default because some gateways answer unsigned — the situation feedback code 3802 warns about.
  - `Require`: unsigned content raises the new `OsciError.UnsignedContent`.
- The verification result is surfaced as `ContentSignatureStatus` (`Valid` / `Unsigned`) on `OsciMessage.signature` for mailbox fetches and on `Laufzettel.contentSignature` for mediate responses.
- Both new errors carry the `messageId` when one is known, so failed deliveries can still be correlated (the failure Laufzettel picks it up too).
- The properties config supports an optional `tenant.<id>.contentSignatures = require | warn` key.

**Notes**

- The check verifies the signatures cryptographically against the certificates embedded in the message. Certificate chain and trust validation stays with the caller, as elsewhere in the library.
- Existing behaviour is otherwise unchanged: with the default `Warn` policy, deployments against gateways that answer unsigned keep working; the missing signature just becomes visible.
- README documents the new setting, statuses and error