### PR TITLE
osci: return status, messageId and warnings from request

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ libraryDependencies += "de.thatscalaguy" %% "zustellix-utils" % "0.2.0"
 >   access compile unchanged; pattern matches that destructure every field
 >   need the new one, and codecs/schemas derived from the case-class shape
 >   (circe, doobie, a DB table mirroring `Laufzettel`) must add it.
+> - `OsciClient.request` / `OsciFacade.request` now return `F[OsciResponse]`
+>   instead of `F[String]`: the response payload moved to
+>   `OsciResponse.xml: Option[String]` — `None` (instead of the former `""`)
+>   when the answer had no extractable content — and the intermediary's
+>   `messageId`, `status` and `3xxx` `warnings` are now visible on the
+>   synchronous path too. Callers that only want the payload use
+>   `rsp.xml.getOrElse("")`.
 > - `request` / `send` no longer raise `OsciError.OsciResponse` for `3xxx`
 >   feedback (e.g. `3802` "Signatur des Empfängers über die Annahme- bzw.
 >   Bearbeitungsantwort fehlt") — the call succeeds and the codes land in
@@ -396,7 +403,7 @@ one:
 
 | Operation | OSCI message type | Shape |
 |-----------|-------------------|-------|
-| `OsciClient.request(ags, xml)` | `MediateDelivery` | synchronous request/response (e.g. XMeld Personensuche) |
+| `OsciClient.request(ags, xml)` | `MediateDelivery` | synchronous request/response (e.g. XMeld Personensuche), returns an `OsciResponse` |
 | `OsciClient.send(ags, xml)`    | `StoreDelivery`   | asynchronous: stored in the recipient's mailbox, returns an `OsciReceipt` |
 | `OsciMailbox.pending` / `fetch`| `FetchProcessCard` / `FetchDelivery` | asynchronous receive + ack from your own mailbox (e.g. XFamilie) |
 
@@ -446,12 +453,25 @@ object SendDemo extends IOApp.Simple:
       dvdv <- DvdvClient.resource[IO](dvdvConfig)
       osci <- OsciClient.resource[IO](osciConfig, dvdv, LaufzettelSink.console[IO])
     yield osci).use { osci =>
-      osci.request(ags = "01001000", xml = "<xmeld>...</xmeld>").flatMap(IO.println)
+      osci.request(ags = "01001000", xml = "<xmeld>...</xmeld>").flatMap { rsp =>
+        IO.println(s"[${rsp.status}] ${rsp.xml.getOrElse("<no content>")}")
+      }
     }
 ```
 
 The given `DvdvClient` is owned by the caller — the `OsciClient` resource does
 not close it.
+
+`request` returns an `OsciResponse(xml, messageId, status, warnings)`:
+
+- `xml: Option[String]` — the recipient's decrypted (and per policy
+  signature-checked) response payload; `None` when the answer carried no
+  extractable content;
+- `messageId: String` — the intermediary-issued message id, the handle for
+  any later process-card inquiry;
+- `status: String` — the top OSCI feedback code (e.g. `"0800"`);
+- `warnings: List[OsciFeedback]` — warning-class (`3xxx`) feedback, e.g.
+  `3802` (see [OSCI feedback codes](#osci-feedback-codes)).
 
 ### Asynchronous send (StoreDelivery)
 
@@ -734,7 +754,7 @@ the four-digit code:
 | Class  | Meaning | Handling |
 |--------|---------|----------|
 | `0xxx` | success | normal result |
-| `3xxx` | warning — the request **was** executed | tolerated; surfaced as `OsciFeedback(code, text)` in `OsciReceipt.warnings` and `Laufzettel.warnings` |
+| `3xxx` | warning — the request **was** executed | tolerated; surfaced as `OsciFeedback(code, text)` in `OsciResponse.warnings`, `OsciReceipt.warnings` and `Laufzettel.warnings` |
 | `9xxx` | error — the request was not executed | raised as `OsciError.OsciResponse` (with the intermediary's `messageId` when one was already issued) |
 
 All feedback rows are inspected, so an error behind a per-language duplicate

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciClient.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciClient.scala
@@ -10,9 +10,12 @@ import de.osci.osci12.extinterfaces.TransportI
 trait OsciClient[F[_]] {
 
   /** Synchronous request/response (`MediateDelivery`): the recipient answers
-   *  within the call, e.g. the XMeld Personensuche.
+   *  within the call, e.g. the XMeld Personensuche. The returned
+   *  [[OsciResponse]] carries the response payload (`None` when the answer
+   *  had no extractable content) together with the intermediary's
+   *  `messageId`, `status` and `3xxx` warnings.
    */
-  def request(ags: String, xml: String): F[String]
+  def request(ags: String, xml: String): F[OsciResponse]
 
   /** Asynchronous send (`StoreDelivery`): stores the message in the
    *  recipient's mailbox at their intermediary and returns a receipt; the

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciFacade.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciFacade.scala
@@ -5,7 +5,7 @@ import cats.syntax.all.*
 import de.thatscalaguy.zustellix.dvdv.DvdvClient
 
 trait OsciFacade[F[_]] {
-  def request(tenant: TenantId, ags: String, xml: String): F[String]
+  def request(tenant: TenantId, ags: String, xml: String): F[OsciResponse]
   def send(tenant: TenantId, ags: String, xml: String): F[OsciReceipt]
 }
 

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciResponse.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciResponse.scala
@@ -1,0 +1,22 @@
+package de.thatscalaguy.zustellix.osci
+
+/** Result of a synchronous `request` (MediateDelivery): the recipient's
+ *  answer plus the transmission metadata the intermediary reported.
+ *
+ *  @param xml       the recipient's response payload, decrypted and (per the
+ *                   configured [[ContentSignaturePolicy]]) signature-checked —
+ *                   `None` when the response carried no extractable content
+ *  @param messageId the OSCI message id issued by the intermediary — the
+ *                   handle for any later process-card inquiry
+ *  @param status    top OSCI feedback code (e.g. "0800")
+ *  @param warnings  warning-class (`3xxx`) feedback entries — the request was
+ *                   executed, but the intermediary flagged something (e.g.
+ *                   `3802` "Signatur des Empfängers über die Annahme- bzw.
+ *                   Bearbeitungsantwort fehlt")
+ */
+final case class OsciResponse(
+    xml:       Option[String],
+    messageId: String,
+    status:    String,
+    warnings:  List[OsciFeedback] = Nil
+)

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/FacadeImpl.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/FacadeImpl.scala
@@ -2,12 +2,18 @@ package de.thatscalaguy.zustellix.osci.internal
 
 import cats.Monad
 import cats.syntax.all.*
-import de.thatscalaguy.zustellix.osci.{OsciFacade, OsciReceipt, TenantId, TenantRegistry}
+import de.thatscalaguy.zustellix.osci.{
+  OsciFacade,
+  OsciReceipt,
+  OsciResponse,
+  TenantId,
+  TenantRegistry
+}
 
 private[osci] final class FacadeImpl[F[_]: Monad](registry: TenantRegistry[F])
     extends OsciFacade[F] {
 
-  def request(tenant: TenantId, ags: String, xml: String): F[String] =
+  def request(tenant: TenantId, ags: String, xml: String): F[OsciResponse] =
     registry.lookup(tenant).flatMap(_.request(ags, xml))
 
   def send(tenant: TenantId, ags: String, xml: String): F[OsciReceipt] =

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibBridge.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciBibBridge.scala
@@ -138,7 +138,7 @@ private[osci] final class OsciBibBridgeImpl[F[_]: Sync](
         )
 
         OsciRawResult(
-          responseXml = verified.map(_._1).getOrElse(""),
+          responseXml = verified.map(_._1),
           messageId   = msgIdResp.getMessageId,
           status      = topFeedbackCode(rsp.getFeedback),
           warnings    = feedbackWarnings(rsp.getFeedback),

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
@@ -8,6 +8,7 @@ import de.thatscalaguy.zustellix.osci.{
   OsciClient,
   OsciError,
   OsciReceipt,
+  OsciResponse,
   TenantId
 }
 
@@ -21,7 +22,7 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
     sink:      LaufzettelSink[F]
 ) extends OsciClient[F] {
 
-  def request(ags: String, xml: String): F[String] =
+  def request(ags: String, xml: String): F[OsciResponse] =
     for {
       route  <- resolver.resolve(ags)
                   .onError { case e => recordFailure(ags, None, e) }
@@ -34,13 +35,18 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
                   recipientAgs = ags,
                   recipientUri = route.addresseeUri,
                   status       = result.status,
-                  rawXml       = result.responseXml,
+                  rawXml       = result.responseXml.getOrElse(""),
                   warnings     = result.warnings,
                   contentSignature = result.signature
                 )
       _      <- sink.record(tenantId, lz).attempt.void
     }
-    yield result.responseXml
+    yield OsciResponse(
+      xml       = result.responseXml,
+      messageId = result.messageId,
+      status    = result.status,
+      warnings  = result.warnings
+    )
 
   def send(ags: String, xml: String): F[OsciReceipt] =
     for {

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciTransport.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciTransport.scala
@@ -23,11 +23,12 @@ final case class OsciRoute(
 )
 
 /** Raw OSCI transmission result, before being mapped into a domain Laufzettel.
+ *  `responseXml` is `None` when the response carried no extractable content.
  *  `signature` is the verified content-signature status of `responseXml`
  *  (`None` when the response carried no content to check).
  */
 final case class OsciRawResult(
-    responseXml: String,
+    responseXml: Option[String],
     messageId:   String,
     status:      String,
     warnings:    List[OsciFeedback] = Nil,

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/TenantRegistrySpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/TenantRegistrySpec.scala
@@ -6,7 +6,8 @@ import munit.CatsEffectSuite
 class TenantRegistrySpec extends CatsEffectSuite {
 
   private def fakeClient(tag: String): OsciClient[IO] = new OsciClient[IO] {
-    def request(ags: String, xml: String): IO[String] = IO.pure(s"$tag:$ags")
+    def request(ags: String, xml: String): IO[OsciResponse] =
+      IO.pure(OsciResponse(Some(s"$tag:$ags"), s"$tag-msg", "0800"))
     def send(ags: String, xml: String): IO[OsciReceipt] =
       IO.pure(OsciReceipt(s"$tag-msg", "0800", None))
   }
@@ -14,7 +15,10 @@ class TenantRegistrySpec extends CatsEffectSuite {
   test("inMemory.lookup returns the registered client") {
     val alice = fakeClient("alice")
     val reg   = TenantRegistry.inMemory[IO](Map(TenantId("alice") -> alice))
-    reg.lookup(TenantId("alice")).flatMap(_.request("01", "x")).assertEquals("alice:01")
+    reg.lookup(TenantId("alice"))
+      .flatMap(_.request("01", "x"))
+      .map(_.xml)
+      .assertEquals(Some("alice:01"))
   }
 
   test("inMemory.lookup raises UnknownTenant on miss") {

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
@@ -56,8 +56,8 @@ class OsciClientImplSpec extends CatsEffectSuite {
       IO.raiseError(new RuntimeException("sink down"))
   }
 
-  test("happy path returns response xml and records a Laufzettel") {
-    val raw = OsciRawResult("<resp/>", "msg-1", "OK")
+  test("happy path returns the response and records a Laufzettel") {
+    val raw = OsciRawResult(Some("<resp/>"), "msg-1", "OK")
     Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
       val impl = new OsciClientImpl[IO](
         TenantId("alice"),
@@ -71,7 +71,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
         seen <- ref.get
       }
       yield {
-        assertEquals(out, "<resp/>")
+        assertEquals(out, OsciResponse(Some("<resp/>"), "msg-1", "OK"))
         assertEquals(seen.size, 1)
         assertEquals(seen.head.messageId, "msg-1")
         assertEquals(seen.head.recipientAgs, Ags)
@@ -80,9 +80,8 @@ class OsciClientImplSpec extends CatsEffectSuite {
     }
   }
 
-  test("feedback warnings from the transport land on the Laufzettel") {
-    val warning = OsciFeedback("3802", "Signatur des Empfängers fehlt")
-    val raw     = OsciRawResult("<resp/>", "msg-1", "3802", List(warning))
+  test("request: a response without extractable content yields xml = None") {
+    val raw = OsciRawResult(None, "msg-1", "0800")
     Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
       val impl = new OsciClientImpl[IO](
         TenantId("alice"),
@@ -96,7 +95,29 @@ class OsciClientImplSpec extends CatsEffectSuite {
         seen <- ref.get
       }
       yield {
-        assertEquals(out, "<resp/>")
+        assertEquals(out, OsciResponse(None, "msg-1", "0800"))
+        assertEquals(seen.head.rawXml, "")
+      }
+    }
+  }
+
+  test("feedback warnings from the transport land on the response and the Laufzettel") {
+    val warning = OsciFeedback("3802", "Signatur des Empfängers fehlt")
+    val raw     = OsciRawResult(Some("<resp/>"), "msg-1", "3802", List(warning))
+    Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
+      val impl = new OsciClientImpl[IO](
+        TenantId("alice"),
+        "XMeld",
+        fixedTransport(raw),
+        fixedResolver(Route),
+        recordingSink(ref)
+      )
+      for {
+        out  <- impl.request(Ags, "<req/>")
+        seen <- ref.get
+      }
+      yield {
+        assertEquals(out, OsciResponse(Some("<resp/>"), "msg-1", "3802", List(warning)))
         assertEquals(seen.head.status, "3802")
         assertEquals(seen.head.warnings, List(warning))
       }
@@ -105,7 +126,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
 
   test("the content-signature status from the transport lands on the Laufzettel") {
     val raw = OsciRawResult(
-      "<resp/>", "msg-1", "0800", Nil, Some(ContentSignatureStatus.Unsigned)
+      Some("<resp/>"), "msg-1", "0800", Nil, Some(ContentSignatureStatus.Unsigned)
     )
     Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
       val impl = new OsciClientImpl[IO](
@@ -203,7 +224,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
       val impl = new OsciClientImpl[IO](
         TenantId("alice"),
         "XMeld",
-        fixedTransport(OsciRawResult("<x/>", "m", "OK")),
+        fixedTransport(OsciRawResult(Some("<x/>"), "m", "OK")),
         failingResolver(err),
         recordingSink(ref)
       )
@@ -241,7 +262,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
     val impl = new OsciClientImpl[IO](
       TenantId("alice"),
       "XMeld",
-      fixedTransport(OsciRawResult("<x/>", "m", "OK")),
+      fixedTransport(OsciRawResult(Some("<x/>"), "m", "OK")),
       failingResolver(OsciError.AgsNotInDvdv("nope", "u")),
       LaufzettelSink.noop[IO]
     )
@@ -267,7 +288,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
   }
 
   test("sink failure does not fail request") {
-    val raw  = OsciRawResult("<resp/>", "m", "OK")
+    val raw  = OsciRawResult(Some("<resp/>"), "m", "OK")
     val impl = new OsciClientImpl[IO](
       TenantId("alice"),
       "XMeld",
@@ -275,7 +296,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
       fixedResolver(Route),
       failingSink
     )
-    impl.request(Ags, "<req/>").assertEquals("<resp/>")
+    impl.request(Ags, "<req/>").assertEquals(OsciResponse(Some("<resp/>"), "m", "OK"))
   }
 
   test("send happy path returns the receipt and records a Laufzettel without payload") {


### PR DESCRIPTION
Closes #3.

`OsciClient.request` returned only the response payload as `F[String]`. The `messageId`, `status` and `3xxx` warnings from `OsciRawResult` were dropped, so callers could not see warnings like `3802` on the synchronous path. A response without extractable content also came back as `""` instead of a typed signal.

## Changes

- New `OsciResponse(xml: Option[String], messageId: String, status: String, warnings: List[OsciFeedback])` in the `osci` package.
- `OsciClient.request` and `OsciFacade.request` now return `F[OsciResponse]` instead of `F[String]`.
- The payload is `xml: Option[String]`: `None` when the response had no extractable content. Internally, `OsciRawResult.responseXml` is now an `Option[String]` too, so the bridge no longer flattens the missing-content case to `""` (`OsciBibBridge.mediate`).
- The `Laufzettel` is unchanged: `rawXml` keeps its empty-string convention for a response without content, same as before.
- README: documented the new return type, added it to the feedback-code table and to the 0.4.x migration notes.

## Breaking change

Binary and source breaking on `request`, as flagged in the issue (must land before v0.4.0). Callers that only want the payload use `rsp.xml.getOrElse("")`. MiMa passes since there is no 0.4.x release yet.