### PR TITLE
osci: surface mailbox warnings from pending and fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ libraryDependencies += "de.thatscalaguy" %% "zustellix-utils" % "0.2.0"
 >   duplicate row raises where it previously slipped through, and the
 >   mailbox's `pending` / `fetch` no longer abort on `3800` / `3801`
 >   ("more available than the fetch limit").
+> - `OsciMailbox.pending` now returns `F[PendingPage]` instead of
+>   `F[List[PendingDelivery]]`: the deliveries moved to
+>   `PendingPage.deliveries`, and the response's `3xxx` `warnings` ride
+>   along — `PendingPage.truncated` (derived from `3800` / `3801`) finally
+>   tells "mailbox fully listed" apart from "listing cut off at
+>   `fetchLimit`", which `size == fetchLimit` alone could not.
+> - `OsciMessage` gained a `warnings: List[OsciFeedback] = Nil` field for
+>   the `3xxx` feedback of the fetch response. Construction and field access
+>   compile unchanged; pattern matches that destructure every field need the
+>   new one.
 > - `OsciError.OsciResponse` gained a `messageId: Option[String] = None`
 >   field. Construction compiles unchanged; pattern matches that destructure
 >   every field need the new one.
@@ -522,15 +532,23 @@ val mailboxConfig = OsciMailboxConfig(
 
 OsciMailbox.resource[IO](mailboxConfig, cert).use { mailbox =>
   for
-    waiting <- mailbox.pending                    // un-fetched deliveries, process cards only
-    _       <- waiting.traverse_ { p =>
-                 mailbox.fetch(p.messageId).flatMap { msg =>
-                   IO.println(s"${msg.messageId} [${msg.subject}]: ${msg.xml}")
-                 }
-               }
+    page <- mailbox.pending                       // un-fetched deliveries, process cards only
+    _    <- page.deliveries.traverse_ { p =>
+              mailbox.fetch(p.messageId).flatMap { msg =>
+                IO.println(s"${msg.messageId} [${msg.subject}]: ${msg.xml}")
+              }
+            }
+    _    <- IO.println("more waiting, poll again").whenA(page.truncated)
   yield ()
 }
 ```
+
+A `pending` listing is capped at `fetchLimit`. When the mailbox holds more,
+the intermediary flags the response with feedback code `3800` / `3801` —
+surfaced as `PendingPage.truncated` (the raw entries are in
+`PendingPage.warnings`). Since fetching acknowledges (see below), fetch the
+listed deliveries and call `pending` again for the next page; the count of a
+page alone cannot tell a full listing from a cut-off one.
 
 **Acknowledgement semantics.** OSCI 1.2 has no separate ack message — a
 successful `fetch` makes the intermediary record a *reception* entry on the
@@ -754,7 +772,7 @@ the four-digit code:
 | Class  | Meaning | Handling |
 |--------|---------|----------|
 | `0xxx` | success | normal result |
-| `3xxx` | warning — the request **was** executed | tolerated; surfaced as `OsciFeedback(code, text)` in `OsciResponse.warnings`, `OsciReceipt.warnings` and `Laufzettel.warnings` |
+| `3xxx` | warning — the request **was** executed | tolerated; surfaced as `OsciFeedback(code, text)` in `OsciResponse.warnings`, `OsciReceipt.warnings`, `Laufzettel.warnings`, `PendingPage.warnings` and `OsciMessage.warnings` |
 | `9xxx` | error — the request was not executed | raised as `OsciError.OsciResponse` (with the intermediary's `messageId` when one was already issued) |
 
 All feedback rows are inspected, so an error behind a per-language duplicate

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMailbox.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMailbox.scala
@@ -23,13 +23,17 @@ trait OsciMailbox[F[_]] {
 
   /** Deliveries addressed to this mailbox that nobody has fetched yet
    *  (`FetchProcessCard` with `selectNoReceptionOnly`), oldest first, at most
-   *  `fetchLimit` entries.
+   *  `fetchLimit` entries. The page carries the response's `3xxx` warnings;
+   *  [[PendingPage.truncated]] tells whether the listing was cut off at
+   *  `fetchLimit` (feedback code `3800` / `3801`) — more deliveries are then
+   *  waiting than the page lists.
    */
-  def pending: F[List[PendingDelivery]]
+  def pending: F[PendingPage]
 
   /** Fetches one delivery by message id (`FetchDelivery`) and decrypts its
    *  content with our own cipher cert. Raises [[OsciError.NoSuchMessage]]
-   *  when the response carries no content for the id.
+   *  when the response carries no content for the id. `3xxx` warnings on the
+   *  response are surfaced via [[OsciMessage.warnings]].
    */
   def fetch(messageId: String): F[OsciMessage]
 }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMessage.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciMessage.scala
@@ -11,12 +11,42 @@ final case class PendingDelivery(
     creation:  Option[Instant]
 )
 
+/** One [[OsciMailbox.pending]] listing: the un-fetched deliveries plus the
+ *  warning-class (`3xxx`) feedback of the response. The warning that matters
+ *  here is `3800` / `3801` ("more available than the fetch limit"): it is the
+ *  only reliable signal that the listing was cut off at `fetchLimit` —
+ *  `deliveries.size == fetchLimit` alone is ambiguous. [[truncated]] derives
+ *  it; when it is `true`, fetch (and thereby acknowledge) the listed
+ *  deliveries and call `pending` again for the rest.
+ */
+final case class PendingPage(
+    deliveries: List[PendingDelivery],
+    warnings:   List[OsciFeedback] = Nil
+) {
+
+  /** True when the intermediary flagged the listing as incomplete (feedback
+   *  code `3800` or `3801`) — more deliveries are waiting than `fetchLimit`
+   *  allowed to list.
+   */
+  def truncated: Boolean = warnings.exists(w => PendingPage.TruncationCodes(w.code))
+}
+
+object PendingPage {
+
+  /** OSCI 1.2 feedback codes reporting a selection cut off at the requested
+   *  quantity limit.
+   */
+  val TruncationCodes: Set[String] = Set("3800", "3801")
+}
+
 /** A fetched delivery. `reception` is the intermediary's reception entry on
  *  the process card — the acknowledgement mark (see [[OsciMailbox]]).
  *  `signature` is the verified status of the author's content signature over
  *  `xml`; it is [[ContentSignatureStatus.Unsigned]] only under
  *  [[ContentSignaturePolicy.Warn]] — an invalid signature never yields a
- *  message but raises [[OsciError.InvalidContentSignature]].
+ *  message but raises [[OsciError.InvalidContentSignature]]. `warnings` are
+ *  the warning-class (`3xxx`) feedback entries of the fetch response — the
+ *  delivery was returned, but the intermediary flagged something.
  */
 final case class OsciMessage(
     messageId: String,
@@ -24,5 +54,6 @@ final case class OsciMessage(
     xml:       String,
     creation:  Option[Instant],
     reception: Option[Instant],
-    signature: ContentSignatureStatus
+    signature: ContentSignatureStatus,
+    warnings:  List[OsciFeedback] = Nil
 )

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciMailboxBridge.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciMailboxBridge.scala
@@ -6,7 +6,8 @@ import de.thatscalaguy.zustellix.osci.{
   OsciMailbox,
   OsciMailboxConfig,
   OsciMessage,
-  PendingDelivery
+  PendingDelivery,
+  PendingPage
 }
 
 import de.osci.osci12.common.DialogHandler
@@ -32,7 +33,7 @@ private[osci] final class OsciMailboxBridgeImpl[F[_]: Sync](
 
   import OsciBibSupport.*
 
-  def pending: F[List[PendingDelivery]] =
+  def pending: F[PendingPage] =
     Sync[F].blocking {
       try withDialog { dialog =>
         val fpc = new FetchProcessCard(dialog)
@@ -43,13 +44,15 @@ private[osci] final class OsciMailboxBridgeImpl[F[_]: Sync](
         val rsp = fpc.send()
         checkFeedback(rsp.getFeedback)
 
-        Option(rsp.getProcessCardBundles).map(_.toList).getOrElse(Nil).map { pc =>
-          PendingDelivery(
-            messageId = pc.getMessageId,
-            subject   = Option(pc.getSubject),
-            creation  = parseTimestamp(pc.getCreation)
-          )
-        }
+        val deliveries =
+          Option(rsp.getProcessCardBundles).map(_.toList).getOrElse(Nil).map { pc =>
+            PendingDelivery(
+              messageId = pc.getMessageId,
+              subject   = Option(pc.getSubject),
+              creation  = parseTimestamp(pc.getCreation)
+            )
+          }
+        PendingPage(deliveries, feedbackWarnings(rsp.getFeedback))
       }
       catch {
         case e: Exception => throw toOsciError(e)
@@ -80,7 +83,8 @@ private[osci] final class OsciMailboxBridgeImpl[F[_]: Sync](
           xml       = xml,
           creation  = parseTimestamp(rsp.getTimestampCreation),
           reception = Option(rsp.getProcessCardBundle).flatMap(pc => parseTimestamp(pc.getReception)),
-          signature = signature
+          signature = signature,
+          warnings  = feedbackWarnings(rsp.getFeedback)
         )
       }
       catch {

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/PendingPageSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/PendingPageSpec.scala
@@ -1,0 +1,47 @@
+package de.thatscalaguy.zustellix.osci
+
+import munit.FunSuite
+
+/** The truncation contract of a `pending` listing: only the intermediary's
+ *  3800/3801 feedback distinguishes "mailbox fully listed" from "listing cut
+ *  off at fetchLimit" — `deliveries.size == fetchLimit` is ambiguous.
+ */
+class PendingPageSpec extends FunSuite {
+
+  test("truncated is false without warnings") {
+    assertEquals(PendingPage(Nil).truncated, false)
+  }
+
+  test("truncated is true on a 3800 warning") {
+    val page = PendingPage(Nil, List(OsciFeedback("3800", "Auswahl unvollständig")))
+    assertEquals(page.truncated, true)
+  }
+
+  test("truncated is true on a 3801 warning") {
+    val page = PendingPage(Nil, List(OsciFeedback("3801", "Auswahl unvollständig")))
+    assertEquals(page.truncated, true)
+  }
+
+  test("truncated is false on unrelated warnings (e.g. 3802)") {
+    val page = PendingPage(
+      Nil,
+      List(OsciFeedback("3802", "Signatur des Empfängers fehlt"))
+    )
+    assertEquals(page.truncated, false)
+  }
+
+  test("truncated finds the truncation code among other warnings") {
+    val page = PendingPage(
+      Nil,
+      List(
+        OsciFeedback("3802", "Signatur des Empfängers fehlt"),
+        OsciFeedback("3800", "Auswahl unvollständig")
+      )
+    )
+    assertEquals(page.truncated, true)
+  }
+
+  test("warnings default to Nil") {
+    assertEquals(PendingPage(Nil).warnings, Nil)
+  }
+}


### PR DESCRIPTION
Closes #11.

`pending` and `fetch` checked the OSCI feedback for errors but threw the warning-class (`3xxx`) entries away. The one that hurts is `3800`/`3801` ("more available than the fetch limit"): without it a caller cannot tell a fully listed mailbox from a listing cut off at `fetchLimit` — `deliveries.size == fetchLimit` is ambiguous.

Changes:

- `OsciMailbox.pending` now returns `F[PendingPage]` instead of `F[List[PendingDelivery]]`. The page holds the deliveries plus the response's `3xxx` warnings, and `PendingPage.truncated` is derived from `3800`/`3801`. When it is `true`, fetch the listed deliveries (fetching acknowledges them) and call `pending` again for the rest.
- `OsciMessage` gained `warnings: List[OsciFeedback] = Nil` with the `3xxx` feedback of the fetch response. Construction and field access compile unchanged; pattern matches that destructure every field need the new one.
- The bridge collects the warnings via the existing `feedbackWarnings` helper (deduplicated per code, same as `OsciResponse`/`OsciReceipt`/`Laufzettel`).
- README: mailbox example, 0.4.x migration notes and the feedback-code table cover the new fields.

Binary breaking (the `pending` signature and the `OsciMessage` shape), so this needs to land before v0.4.0 — same batch as 