### PR TITLE
osci: make Laufzettel payload capture opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ libraryDependencies += "de.thatscalaguy" %% "zustellix-utils" % "0.2.0"
 >   access compile unchanged; pattern matches that destructure every field
 >   need the new one, and codecs/schemas derived from the case-class shape
 >   (circe, doobie, a DB table mirroring `Laufzettel`) must add it.
+> - `Laufzettel.rawXml` is now `Option[String]` and **empty by default**. The
+>   decrypted response XML of a `request` contains personal data, so it is no
+>   longer handed to the sink unless payload capture is explicitly enabled
+>   with `OsciConfig.capturePayloads = true` (properties key
+>   `tenant.<id>.capturePayloads`) — see [Laufzettel](#laufzettel). With
+>   capture on, a response without extractable content is `None` (instead of
+>   the former `""`); for `send` and failure records it is always `None`.
+>   Codecs/schemas derived from the case-class shape (circe, doobie, a DB
+>   table mirroring `Laufzettel`) must make the column nullable, and sinks
+>   that relied on the payload must opt in.
 > - `OsciClient.request` / `OsciFacade.request` now return `F[OsciResponse]`
 >   instead of `F[String]`: the response payload moved to
 >   `OsciResponse.xml: Option[String]` — `None` (instead of the former `""`)
@@ -114,7 +124,7 @@ libraryDependencies += "de.thatscalaguy" %% "zustellix-utils" % "0.2.0"
 >   [Laufzettel](#laufzettel)). Sinks that treated every record as a
 >   delivered message must check `status`: `0xxx` / `3xxx` is delivered,
 >   anything else (a `9xxx` code or an error kind like `OsciTransport`) is a
->   failure record with empty `rawXml`.
+>   failure record with `rawXml = None`.
 
 ---
 
@@ -682,6 +692,7 @@ tenant.flensburg.subject          = XMeld
 tenant.flensburg.connectTimeoutMs = 5000
 tenant.flensburg.readTimeoutMs    = 60000
 tenant.flensburg.contentSignatures = require
+tenant.flensburg.capturePayloads   = true
 
 tenant.kiel.cert.type     = pem
 tenant.kiel.cert.path     = /secrets/kiel-cert.pem
@@ -692,7 +703,9 @@ tenant.kiel.cert.password = optional-key-password
 (`serviceUri` and `subject` are optional and default to the XMeld
 Personensuche WSDL and `XMeld`; `connectTimeoutMs` / `readTimeoutMs` are
 optional and default to 10 s / 120 s; `contentSignatures` is optional —
-`require` or `warn`, default `warn`.)
+`require` or `warn`, default `warn`; `capturePayloads` is optional —
+`true` stores the decrypted response XML on `Laufzettel.rawXml`, default
+`false`, see [Laufzettel](#laufzettel).)
 
 Multi-tenant mailboxes are simply multiple `OsciMailbox.resource` calls — one
 per tenant cert/intermediary.
@@ -719,8 +732,7 @@ OsciMailbox.resource[IO](mailboxConfig, certManager, alias)
 
 Each `request` / `send` produces a `Laufzettel(messageId, timestamp,
 recipientAgs, recipientUri, status, rawXml, warnings, contentSignature)`
-handed to a `LaufzettelSink[F]` (for `send`, `rawXml` is empty and
-`contentSignature` is `None` — there is no response payload at store time):
+handed to a `LaufzettelSink[F]`:
 
 ```scala
 LaufzettelSink.console[IO]   // prints a one-line summary
@@ -731,6 +743,20 @@ val toDb: LaufzettelSink[IO] = new LaufzettelSink[IO]:
   def record(tenant: TenantId, l: Laufzettel): IO[Unit] = repo.insert(tenant, l)
 ```
 
+**`rawXml` is `None` by default.** The decrypted response XML of a `request`
+(e.g. an XMeld Personensuche answer) contains personal data, and whatever
+the sink writes to — a DB, a queue, a log shipper — would persist it with
+every record. Set `OsciConfig.capturePayloads = true` (properties key
+`tenant.<id>.capturePayloads`) to store it on the Laufzettel; do that only
+when the sink is meant to hold the payload and your data-protection rules
+(retention, access, deletion) cover it. The caller always gets the payload
+via `OsciResponse.xml` — capture only affects what the sink sees.
+
+For `send` there is no response payload at store time, so `rawXml` and
+`contentSignature` stay `None` regardless of the flag. The content signature
+of a `request` response is verified independently of capture —
+`contentSignature` is filled even when `rawXml` is not.
+
 Failed deliveries are recorded too, so the sink sees the complete audit
 trail, not just successes. For a failure Laufzettel:
 
@@ -739,7 +765,7 @@ trail, not just successes. For a failure Laufzettel:
   `OsciTransport`, `AgsNotInDvdv`);
 - `messageId` is the id issued by `GetMessageId` when the delivery got that
   far, `""` otherwise;
-- `rawXml` is empty, `warnings` is `Nil`;
+- `rawXml` is `None`, `warnings` is `Nil`;
 - `recipientUri` is empty when the resolver itself failed (no route exists).
 
 Recording stays best-effort in both directions: a sink failure never fails

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/Laufzettel.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/Laufzettel.scala
@@ -3,9 +3,16 @@ package de.thatscalaguy.zustellix.osci
 import java.net.URI
 import java.time.Instant
 
-/** `contentSignature` is the verified status of the author's content
- *  signature over `rawXml` — `None` when there was no response content to
- *  check (async `send`, failures).
+/** `rawXml` is the decrypted response payload of a synchronous `request` —
+ *  captured only when `OsciConfig.capturePayloads` is enabled, `None`
+ *  otherwise (and always for async `send` and failures, which have no
+ *  response payload). The payload can contain personal data, which is why
+ *  capture is opt-in — see the README's Laufzettel section.
+ *
+ *  `contentSignature` is the verified status of the author's content
+ *  signature over the response content — `None` when there was no response
+ *  content to check (async `send`, failures). It is filled independently of
+ *  `rawXml`: the signature is verified even when the payload is not captured.
  */
 final case class Laufzettel(
     messageId:    String,
@@ -13,7 +20,7 @@ final case class Laufzettel(
     recipientAgs: String,
     recipientUri: URI,
     status:       String,
-    rawXml:       String,
+    rawXml:       Option[String] = None,
     warnings:     List[OsciFeedback] = Nil,
     contentSignature: Option[ContentSignatureStatus] = None
 )

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciClient.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciClient.scala
@@ -68,7 +68,9 @@ object OsciClient {
     Resource.eval(certSource)
       .flatMap(internal.OsciBibBridge.resource[F](_, transport, config.contentSignatures))
       .map { bridge =>
-        new internal.OsciClientImpl[F](config.tenantId, config.subject, bridge, resolver, sink)
+        new internal.OsciClientImpl[F](
+          config.tenantId, config.subject, bridge, resolver, sink, config.capturePayloads
+        )
       }
   }
 
@@ -102,7 +104,7 @@ object OsciClient {
       cred   <- Resource.eval(certs.resolve(alias))
       bridge <- internal.OsciBibBridge.resource[F](cred, transport, config.contentSignatures)
     } yield new internal.OsciClientImpl[F](
-      TenantId(alias.value), config.subject, bridge, resolver, sink
+      TenantId(alias.value), config.subject, bridge, resolver, sink, config.capturePayloads
     )
   }
 

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciConfig.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciConfig.scala
@@ -18,6 +18,12 @@ import scala.concurrent.duration.FiniteDuration
  *  `contentSignatures` sets how strictly the author's content signature on
  *  received response content (synchronous `request` answers) is enforced —
  *  see [[ContentSignaturePolicy]].
+ *
+ *  `capturePayloads` opts in to storing the decrypted response XML of a
+ *  `request` on [[Laufzettel.rawXml]]. Off by default: XMeld responses
+ *  contain personal data, and every `LaufzettelSink` (DB, queue, log
+ *  shipper) would persist it. Enable only when the sink is meant to hold
+ *  the payload and handles it accordingly.
  */
 final case class OsciConfig(
     tenantId: TenantId,
@@ -30,7 +36,8 @@ final case class OsciConfig(
     subject: String = OsciConfig.DefaultSubject,
     connectTimeout: FiniteDuration = OsciHttpTransport.DefaultConnectTimeout,
     readTimeout: FiniteDuration = OsciHttpTransport.DefaultReadTimeout,
-    contentSignatures: ContentSignaturePolicy = ContentSignaturePolicy.Warn
+    contentSignatures: ContentSignaturePolicy = ContentSignaturePolicy.Warn,
+    capturePayloads: Boolean = false
 )
 
 object OsciConfig {

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/FileConfigSource.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/FileConfigSource.scala
@@ -22,6 +22,7 @@ import scala.jdk.CollectionConverters.*
  *   tenant.<id>.connectTimeoutMs       = <millis>            (optional)
  *   tenant.<id>.readTimeoutMs          = <millis>            (optional)
  *   tenant.<id>.contentSignatures      = require | warn      (optional, default warn)
+ *   tenant.<id>.capturePayloads        = true | false        (optional, default false)
  * }}}
  *
  *  The intermediary is no longer configured here — it is resolved per send
@@ -89,6 +90,18 @@ private[osci] final class FileConfigSource[F[_]: Sync](path: Path) extends Confi
         }
       }
 
+    val capturePayloads =
+      kv.get("capturePayloads").fold(false) { v =>
+        v.trim.toLowerCase match {
+          case "true"  => true
+          case "false" => false
+          case other =>
+            throw OsciError.Config(
+              s"tenant.$id.capturePayloads must be 'true' or 'false', got '$other'"
+            )
+        }
+      }
+
     OsciConfig(
       tenantId       = TenantId(id),
       certSource     = Some(certSource),
@@ -96,7 +109,8 @@ private[osci] final class FileConfigSource[F[_]: Sync](path: Path) extends Confi
       subject        = kv.getOrElse("subject", OsciConfig.DefaultSubject),
       connectTimeout = timeoutMs("connectTimeoutMs", OsciHttpTransport.DefaultConnectTimeout),
       readTimeout    = timeoutMs("readTimeoutMs", OsciHttpTransport.DefaultReadTimeout),
-      contentSignatures = contentSignatures
+      contentSignatures = contentSignatures,
+      capturePayloads   = capturePayloads
     )
   }
 }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
@@ -19,7 +19,8 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
     subject:   String,
     transport: OsciTransport[F],
     resolver:  AgsResolver[F],
-    sink:      LaufzettelSink[F]
+    sink:      LaufzettelSink[F],
+    capturePayloads: Boolean = false
 ) extends OsciClient[F] {
 
   def request(ags: String, xml: String): F[OsciResponse] =
@@ -35,7 +36,7 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
                   recipientAgs = ags,
                   recipientUri = route.addresseeUri,
                   status       = result.status,
-                  rawXml       = result.responseXml.getOrElse(""),
+                  rawXml       = if capturePayloads then result.responseXml else None,
                   warnings     = result.warnings,
                   contentSignature = result.signature
                 )
@@ -61,7 +62,7 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
                    recipientAgs = ags,
                    recipientUri = route.addresseeUri,
                    status       = receipt.status,
-                   rawXml       = "", // async: no response payload at store time
+                   rawXml       = None, // async: no response payload at store time
                    warnings     = receipt.warnings
                  )
       _       <- sink.record(tenantId, lz).attempt.void
@@ -72,7 +73,7 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
    *  success-only: `status` carries the OSCI feedback code for a `9xxx`
    *  response and the error kind otherwise, `messageId` the id from
    *  `GetMessageId` when one was issued before the failure ("" otherwise),
-   *  `rawXml` stays empty. `recipientUri` is the resolved addressee URI, or
+   *  `rawXml` stays `None`. `recipientUri` is the resolved addressee URI, or
    *  empty when the resolver itself failed. Recording is best-effort — the
    *  original error is re-raised untouched, and a sink failure is swallowed
    *  like on the success path.
@@ -85,7 +86,7 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
         recipientAgs = ags,
         recipientUri = uri.getOrElse(URI.create("")),
         status       = failureStatus(e),
-        rawXml       = ""
+        rawXml       = None
       )
       sink.record(tenantId, lz).attempt.void
     }

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/ConfigSourceSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/ConfigSourceSpec.scala
@@ -154,6 +154,46 @@ class ConfigSourceSpec extends CatsEffectSuite {
     }
   }
 
+  test("file parses optional capturePayloads and defaults it to false when absent") {
+    val props =
+      """tenant.alice.cert.type       = pkcs12
+        |tenant.alice.cert.path       = /keys/alice.p12
+        |tenant.alice.cert.password   = pw
+        |tenant.alice.capturePayloads = true
+        |tenant.bob.cert.type         = pkcs12
+        |tenant.bob.cert.path         = /keys/bob.p12
+        |tenant.bob.cert.password     = pw
+        |""".stripMargin
+
+    val tmp = Files.createTempFile("osci-cfg-", ".properties")
+    Files.writeString(tmp, props)
+    tmp.toFile.deleteOnExit()
+
+    ConfigSource.file[IO](tmp).load.map { m =>
+      assertEquals(m(TenantId("alice")).capturePayloads, true)
+      assertEquals(m(TenantId("bob")).capturePayloads, false)
+    }
+  }
+
+  test("file raises Config error on an unknown capturePayloads value") {
+    val props =
+      """tenant.alice.cert.type       = pkcs12
+        |tenant.alice.cert.path       = /keys/alice.p12
+        |tenant.alice.cert.password   = pw
+        |tenant.alice.capturePayloads = yes
+        |""".stripMargin
+
+    val tmp = Files.createTempFile("osci-cfg-", ".properties")
+    Files.writeString(tmp, props)
+    tmp.toFile.deleteOnExit()
+
+    ConfigSource.file[IO](tmp).load.attempt.map {
+      case Left(e: OsciError.Config) =>
+        assert(e.getMessage.contains("capturePayloads"), e.getMessage)
+      case other => fail(s"expected Config error, got $other")
+    }
+  }
+
   test("file raises Config error on missing required cert.path") {
     val props =
       """tenant.broken.cert.type     = pkcs12

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/LaufzettelSinkSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/LaufzettelSinkSpec.scala
@@ -14,7 +14,7 @@ class LaufzettelSinkSpec extends CatsEffectSuite {
     recipientAgs = "01001000",
     recipientUri = URI.create("https://example/osci"),
     status       = "OK",
-    rawXml       = "<x/>"
+    rawXml       = Some("<x/>")
   )
 
   test("noop sink completes with Unit") {

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
@@ -76,7 +76,46 @@ class OsciClientImplSpec extends CatsEffectSuite {
         assertEquals(seen.head.messageId, "msg-1")
         assertEquals(seen.head.recipientAgs, Ags)
         assertEquals(seen.head.status, "OK")
+        assertEquals(seen.head.rawXml, None)
       }
+    }
+  }
+
+  test("request: capturePayloads = true records the response payload on the Laufzettel") {
+    val raw = OsciRawResult(Some("<resp/>"), "msg-1", "OK")
+    Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
+      val impl = new OsciClientImpl[IO](
+        TenantId("alice"),
+        "XMeld",
+        fixedTransport(raw),
+        fixedResolver(Route),
+        recordingSink(ref),
+        capturePayloads = true
+      )
+      for {
+        _    <- impl.request(Ags, "<req/>")
+        seen <- ref.get
+      }
+      yield assertEquals(seen.head.rawXml, Some("<resp/>"))
+    }
+  }
+
+  test("request: capturePayloads = true with no extractable content records rawXml = None") {
+    val raw = OsciRawResult(None, "msg-1", "0800")
+    Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
+      val impl = new OsciClientImpl[IO](
+        TenantId("alice"),
+        "XMeld",
+        fixedTransport(raw),
+        fixedResolver(Route),
+        recordingSink(ref),
+        capturePayloads = true
+      )
+      for {
+        _    <- impl.request(Ags, "<req/>")
+        seen <- ref.get
+      }
+      yield assertEquals(seen.head.rawXml, None)
     }
   }
 
@@ -96,7 +135,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
       }
       yield {
         assertEquals(out, OsciResponse(None, "msg-1", "0800"))
-        assertEquals(seen.head.rawXml, "")
+        assertEquals(seen.head.rawXml, None)
       }
     }
   }
@@ -188,7 +227,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
         assertEquals(seen.head.recipientAgs, Ags)
         assertEquals(seen.head.recipientUri, Route.addresseeUri)
         assertEquals(seen.head.status, "9000")
-        assertEquals(seen.head.rawXml, "")
+        assertEquals(seen.head.rawXml, None)
         assertEquals(seen.head.warnings, Nil)
       }
     }
@@ -213,7 +252,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
         assertEquals(seen.size, 1)
         assertEquals(seen.head.messageId, "")
         assertEquals(seen.head.status, "OsciTransport")
-        assertEquals(seen.head.rawXml, "")
+        assertEquals(seen.head.rawXml, None)
       }
     }
   }
@@ -319,7 +358,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
         assertEquals(seen.head.messageId, "msg-2")
         assertEquals(seen.head.recipientAgs, Ags)
         assertEquals(seen.head.status, "0800")
-        assertEquals(seen.head.rawXml, "")
+        assertEquals(seen.head.rawXml, None)
       }
     }
   }
@@ -360,7 +399,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
         assertEquals(seen.head.recipientAgs, Ags)
         assertEquals(seen.head.recipientUri, Route.addresseeUri)
         assertEquals(seen.head.status, "9802")
-        assertEquals(seen.head.rawXml, "")
+        assertEquals(seen.head.rawXml, None)
       }
     }
   }


### PR DESCRIPTION
Closes #14

`Laufzettel.rawXml` used to carry the full decrypted response XML of every `request`. XMeld responses contain personal data, so every sink (DB, queue, log shipper) persisted that data unless the integrator stripped it first.

## Changes

- `Laufzettel.rawXml` is now `Option[String]` and defaults to `None`.
- New flag `OsciConfig.capturePayloads` (default `false`). Only when it is `true` does `request` put the decrypted response XML on the Laufzettel. For `send` and failure records it is always `None` — there is no response payload in those cases.
- The flag is wired through both `OsciClient.resource` overloads and can be set per tenant in the properties file: `tenant.<id>.capturePayloads = true | false`. Any other value raises `OsciError.Config`, like the other keys.
- The content signature check is not affected: `contentSignature` is verified and filled even when the payload is not captured. Callers also still get the payload via `OsciResponse.xml` — the flag only changes what the sink sees.
- README: the Laufzettel section explains the flag and the data-protection reasoning, the properties-file format lists the new key, and the 0.4.x migration notes cover the field type change.

This is binary breaking (field type change on `Laufzettel`, new field on `OsciConfig`), so it must land before v0.4.0. MiMa passes because there is no released 0.4.x to compare against.
