### PR TITLE
osci: replace stringly-typed AGS and error fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ libraryDependencies += "de.thatscalaguy" %% "zustellix-utils" % "0.2.0"
 >   inspecting `warnings`; a remaining `OsciResponse` is a real `9xxx`
 >   failure. `Laufzettel.status` can now carry a `3xxx` code, so
 >   "starts with `0` = success" checks must accept `0xxx` **and** `3xxx`
->   as delivered.
+>   as delivered — `LaufzettelStatus.delivered` does exactly that.
 > - All feedback rows are scanned now: a `9xxx` error behind a per-language
 >   duplicate row raises where it previously slipped through, and the
 >   mailbox's `pending` / `fetch` no longer abort on `3800` / `3801`
@@ -125,6 +125,20 @@ libraryDependencies += "de.thatscalaguy" %% "zustellix-utils" % "0.2.0"
 >   delivered message must check `status`: `0xxx` / `3xxx` is delivered,
 >   anything else (a `9xxx` code or an error kind like `OsciTransport`) is a
 >   failure record with `rawXml = None`.
+> - The AGS is now the opaque type `Ags` instead of a plain `String` — in
+>   `OsciClient.request` / `send`, `OsciFacade.request` / `send`,
+>   `Laufzettel.recipientAgs` and the `ags` field of `AgsNotInDvdv`,
+>   `RecipientCertMissing` and `ServiceElementMissing`. Build one with
+>   `Ags.from(s)` (`Either[OsciError.InvalidAgs, Ags]`, exactly 8 digits) or
+>   `Ags.unsafe(s)` (throws); read the raw string back with `.value`.
+> - `OsciError.RecipientCertMissing` gained a `kind` field naming the
+>   affected service element (`OSCI_ADDRESSEE` / `OSCI_INTERMEDIARY`) — it
+>   was previously appended to the `ags` string.
+> - `Laufzettel.status` is now a `LaufzettelStatus` instead of a `String`:
+>   `Feedback(code)` carries an OSCI feedback code, `Failed(kind)` an error
+>   kind when no code exists. `status.delivered` replaces "starts with `0`
+>   or `3`" checks, and `status.render` yields the previous plain string for
+>   logs and DB columns.
 
 ---
 
@@ -427,6 +441,12 @@ one:
 | `OsciClient.send(ags, xml)`    | `StoreDelivery`   | asynchronous: stored in the recipient's mailbox, returns an `OsciReceipt` |
 | `OsciMailbox.pending` / `fetch`| `FetchProcessCard` / `FetchDelivery` | asynchronous receive + ack from your own mailbox (e.g. XFamilie) |
 
+Recipients are addressed by their `Ags` (amtlicher Gemeindeschlüssel) — an
+opaque type that only admits well-formed keys: `Ags.from("01001000")`
+validates (exactly 8 digits, `Either[OsciError.InvalidAgs, Ags]`),
+`Ags.unsafe(...)` throws on bad input, `.value` reads the raw string back.
+A typo fails at the call site instead of surfacing as a DVDV miss.
+
 Every outbound operation:
 
 1. calls `dvdv.findServiceDescription("ags:<ags>", serviceUri)` **once** per
@@ -473,7 +493,7 @@ object SendDemo extends IOApp.Simple:
       dvdv <- DvdvClient.resource[IO](dvdvConfig)
       osci <- OsciClient.resource[IO](osciConfig, dvdv, LaufzettelSink.console[IO])
     yield osci).use { osci =>
-      osci.request(ags = "01001000", xml = "<xmeld>...</xmeld>").flatMap { rsp =>
+      osci.request(ags = Ags.unsafe("01001000"), xml = "<xmeld>...</xmeld>").flatMap { rsp =>
         IO.println(s"[${rsp.status}] ${rsp.xml.getOrElse("<no content>")}")
       }
     }
@@ -508,7 +528,7 @@ val xfamConfig = OsciConfig(
 )
 
 OsciClient.resource[IO](xfamConfig, dvdv, LaufzettelSink.console[IO]).use { osci =>
-  osci.send(ags = "01001000", xml = "<xfamilie>...</xfamilie>").flatMap { receipt =>
+  osci.send(ags = Ags.unsafe("01001000"), xml = "<xfamilie>...</xfamilie>").flatMap { receipt =>
     IO.println(s"stored as ${receipt.messageId} (status ${receipt.status})")
   }
 }
@@ -677,7 +697,7 @@ val srcFromFile = ConfigSource.file[IO](Paths.get("/etc/zustellix/tenants.proper
 def dvdvFor(t: TenantId): DvdvClient[IO] = clientsByTenant(t)   // caller owns these
 
 OsciFacade.fromConfigs[IO](src, dvdvFor, LaufzettelSink.console[IO]).use { facade =>
-  facade.request(TenantId("kiel"), ags = "01002000", xml = "<xmeld>...</xmeld>")
+  facade.request(TenantId("kiel"), ags = Ags.unsafe("01002000"), xml = "<xmeld>...</xmeld>")
 }
 ```
 
@@ -722,7 +742,7 @@ val alias = CertAlias("flensburg")
 (for
   dvdv <- DvdvClient.resource[IO](dvdvConfig, certManager, alias)
   osci <- OsciClient.resource[IO](osciConfig, certManager, alias, dvdv, LaufzettelSink.console[IO])
-yield osci).use(_.request("01001000", "<xmeld>...</xmeld>"))
+yield osci).use(_.request(Ags.unsafe("01001000"), "<xmeld>...</xmeld>"))
 
 // the mailbox takes the same alias:
 OsciMailbox.resource[IO](mailboxConfig, certManager, alias)
@@ -743,6 +763,12 @@ val toDb: LaufzettelSink[IO] = new LaufzettelSink[IO]:
   def record(tenant: TenantId, l: Laufzettel): IO[Unit] = repo.insert(tenant, l)
 ```
 
+`status` is a `LaufzettelStatus`: `Feedback(code)` when OSCI reported a
+feedback code (`0xxx` / `3xxx` / `9xxx`), `Failed(kind)` when the delivery
+failed before one existed. `status.delivered` is `true` for `0xxx` / `3xxx`
+(the request was executed), and `status.render` gives the plain string —
+the code or the error kind — for logs and DB columns.
+
 **`rawXml` is `None` by default.** The decrypted response XML of a `request`
 (e.g. an XMeld Personensuche answer) contains personal data, and whatever
 the sink writes to — a DB, a queue, a log shipper — would persist it with
@@ -760,9 +786,9 @@ of a `request` response is verified independently of capture —
 Failed deliveries are recorded too, so the sink sees the complete audit
 trail, not just successes. For a failure Laufzettel:
 
-- `status` is the OSCI feedback code for a `9xxx` response
-  (`OsciError.OsciResponse`) and the error kind otherwise (e.g.
-  `OsciTransport`, `AgsNotInDvdv`);
+- `status` is `Feedback` with the `9xxx` code for an OSCI error response
+  (`OsciError.OsciResponse`) and `Failed` with the error kind otherwise
+  (e.g. `OsciTransport`, `AgsNotInDvdv`);
 - `messageId` is the id issued by `GetMessageId` when the delivery got that
   far, `""` otherwise;
 - `rawXml` is `None`, `warnings` is `Nil`;
@@ -779,8 +805,9 @@ All failures are an `OsciError` (a `RuntimeException`):
 | Error                  | When |
 |------------------------|------|
 | `UnknownTenant`        | facade dispatched to a tenant with no registered client |
+| `InvalidAgs`           | the given string is not a well-formed 8-digit AGS (raised by the `Ags` smart constructors) |
 | `AgsNotInDvdv`         | DVDV has no service registered for the AGS + service URI |
-| `RecipientCertMissing` | the service description has no cipher certificate |
+| `RecipientCertMissing` | the service description has no cipher certificate for the element in `kind` |
 | `ServiceElementMissing`| the `OSCI_ADDRESSEE` / `OSCI_INTERMEDIARY` element is absent |
 | `OsciTransport`        | osci-bibliothek transport / IO failure |
 | `OsciResponse`         | OSCI returned an error (`9xxx`) feedback code; carries the `messageId` when one was already issued |

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/Ags.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/Ags.scala
@@ -1,0 +1,27 @@
+package de.thatscalaguy.zustellix.osci
+
+/** Amtlicher Gemeindeschlüssel (AGS) — the 8-digit official municipality key
+ *  that addresses the recipient authority in DVDV lookups.
+ *
+ *  Values only exist via the smart constructors, so an `Ags` is always
+ *  exactly 8 ASCII digits — a malformed key fails fast at the API boundary
+ *  instead of surfacing later as a DVDV miss.
+ */
+opaque type Ags = String
+
+object Ags {
+
+  /** Validates `s` as exactly 8 ASCII digits (leading zeros are
+   *  significant, e.g. `"01001000"`).
+   */
+  def from(s: String): Either[OsciError.InvalidAgs, Ags] =
+    if (s.length == 8 && s.forall(c => c >= '0' && c <= '9')) Right(s)
+    else Left(OsciError.InvalidAgs(s))
+
+  /** Like [[from]], but throws the [[OsciError.InvalidAgs]] — for literals
+   *  and other places where a `Left` cannot occur or cannot be handled.
+   */
+  def unsafe(s: String): Ags = from(s).fold(throw _, identity)
+
+  extension (a: Ags) def value: String = a
+}

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/Laufzettel.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/Laufzettel.scala
@@ -17,9 +17,9 @@ import java.time.Instant
 final case class Laufzettel(
     messageId:    String,
     timestamp:    Instant,
-    recipientAgs: String,
+    recipientAgs: Ags,
     recipientUri: URI,
-    status:       String,
+    status:       LaufzettelStatus,
     rawXml:       Option[String] = None,
     warnings:     List[OsciFeedback] = Nil,
     contentSignature: Option[ContentSignatureStatus] = None

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/LaufzettelSink.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/LaufzettelSink.scala
@@ -16,8 +16,8 @@ object LaufzettelSink {
             if l.warnings.isEmpty then ""
             else l.warnings.map(_.code).mkString(" warnings=", ",", "")
           println(
-            s"[Laufzettel tenant=${tenant.value} ags=${l.recipientAgs} " +
-              s"messageId=${l.messageId} status=${l.status}$warnings " +
+            s"[Laufzettel tenant=${tenant.value} ags=${l.recipientAgs.value} " +
+              s"messageId=${l.messageId} status=${l.status.render}$warnings " +
               s"uri=${l.recipientUri} at=${l.timestamp}]"
           )
         }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/LaufzettelStatus.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/LaufzettelStatus.scala
@@ -1,0 +1,36 @@
+package de.thatscalaguy.zustellix.osci
+
+/** Outcome recorded on a [[Laufzettel]].
+ *
+ *  A delivery that reached OSCI carries the top feedback code the
+ *  intermediary reported — `0xxx` success or `3xxx` warning on the success
+ *  path, `9xxx` when the request was rejected. A delivery that failed before
+ *  OSCI produced any feedback (resolver failure, transport failure, a
+ *  rejected content signature) carries the error kind instead.
+ */
+enum LaufzettelStatus {
+
+  /** Top OSCI feedback code (`0xxx`, `3xxx` or `9xxx`), e.g. `"0800"`. */
+  case Feedback(code: String)
+
+  /** No feedback code exists; `kind` names the [[OsciError]] variant that
+   *  failed the delivery (e.g. `"OsciTransport"`, `"AgsNotInDvdv"`).
+   */
+  case Failed(kind: String)
+
+  /** True when the request was executed: a `0xxx` or `3xxx` feedback code.
+   *  `9xxx` codes and [[Failed]] records are failure records.
+   */
+  def delivered: Boolean = this match {
+    case Feedback(code) => code.startsWith("0") || code.startsWith("3")
+    case Failed(_)      => false
+  }
+
+  /** The plain string form — the feedback code or the error kind — as it
+   *  was stored before this wrapper existed (for logs, DB columns, …).
+   */
+  def render: String = this match {
+    case Feedback(code) => code
+    case Failed(kind)   => kind
+  }
+}

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciClient.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciClient.scala
@@ -15,13 +15,13 @@ trait OsciClient[F[_]] {
    *  had no extractable content) together with the intermediary's
    *  `messageId`, `status` and `3xxx` warnings.
    */
-  def request(ags: String, xml: String): F[OsciResponse]
+  def request(ags: Ags, xml: String): F[OsciResponse]
 
   /** Asynchronous send (`StoreDelivery`): stores the message in the
    *  recipient's mailbox at their intermediary and returns a receipt; the
    *  recipient fetches it later. Used by profiles like XFamilie.
    */
-  def send(ags: String, xml: String): F[OsciReceipt]
+  def send(ags: Ags, xml: String): F[OsciReceipt]
 }
 
 object OsciClient {

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciError.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciError.scala
@@ -8,19 +8,29 @@ object OsciError {
   final case class UnknownTenant(id: TenantId)
       extends OsciError(s"Unknown tenant: ${id.value}")
 
-  final case class AgsNotInDvdv(ags: String, serviceUri: String)
+  /** `input` is not a well-formed AGS (exactly 8 digits) — raised by the
+   *  [[Ags]] smart constructors, never by a lookup.
+   */
+  final case class InvalidAgs(input: String)
+      extends OsciError(s"Invalid AGS '$input': expected exactly 8 digits")
+
+  final case class AgsNotInDvdv(ags: Ags, serviceUri: String)
       extends OsciError(
-        s"AGS '$ags' has no service registered for '$serviceUri' in DVDV"
+        s"AGS '${ags.value}' has no service registered for '$serviceUri' in DVDV"
       )
 
-  final case class RecipientCertMissing(ags: String)
+  /** The service description resolved for `ags` carries no cipher
+   *  certificate for the `kind` service element (`OSCI_ADDRESSEE` or
+   *  `OSCI_INTERMEDIARY`).
+   */
+  final case class RecipientCertMissing(ags: Ags, kind: String)
       extends OsciError(
-        s"DVDV service description for AGS '$ags' has no cipher certificate"
+        s"DVDV service description for AGS '${ags.value}' has no cipher certificate for '$kind'"
       )
 
-  final case class ServiceElementMissing(ags: String, kind: String)
+  final case class ServiceElementMissing(ags: Ags, kind: String)
       extends OsciError(
-        s"DVDV service description for AGS '$ags' is missing service element of type '$kind'"
+        s"DVDV service description for AGS '${ags.value}' is missing service element of type '$kind'"
       )
 
   final case class OsciTransport(cause: Throwable)

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciFacade.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/OsciFacade.scala
@@ -5,8 +5,8 @@ import cats.syntax.all.*
 import de.thatscalaguy.zustellix.dvdv.DvdvClient
 
 trait OsciFacade[F[_]] {
-  def request(tenant: TenantId, ags: String, xml: String): F[OsciResponse]
-  def send(tenant: TenantId, ags: String, xml: String): F[OsciReceipt]
+  def request(tenant: TenantId, ags: Ags, xml: String): F[OsciResponse]
+  def send(tenant: TenantId, ags: Ags, xml: String): F[OsciReceipt]
 }
 
 object OsciFacade {

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/AgsResolver.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/AgsResolver.scala
@@ -4,7 +4,7 @@ import cats.effect.Sync
 import cats.syntax.all.*
 import de.thatscalaguy.zustellix.dvdv.DvdvClient
 import de.thatscalaguy.zustellix.dvdv.model.{Certificate as DvdvCert, ServiceElementInfo, ServiceElementType}
-import de.thatscalaguy.zustellix.osci.{OsciConfig, OsciError}
+import de.thatscalaguy.zustellix.osci.{Ags, OsciConfig, OsciError}
 
 import java.io.ByteArrayInputStream
 import java.net.URI
@@ -12,7 +12,7 @@ import java.security.cert.{CertificateFactory, X509Certificate}
 import java.util.Base64
 
 trait AgsResolver[F[_]] {
-  def resolve(ags: String): F[OsciRoute]
+  def resolve(ags: Ags): F[OsciRoute]
 }
 
 object AgsResolver {
@@ -20,8 +20,8 @@ object AgsResolver {
   def apply[F[_]: Sync](dvdv: DvdvClient[F], config: OsciConfig): AgsResolver[F] =
     new AgsResolver[F] {
 
-      def resolve(ags: String): F[OsciRoute] = {
-        val orgKey = s"ags:$ags"
+      def resolve(ags: Ags): F[OsciRoute] = {
+        val orgKey = s"ags:${ags.value}"
         dvdv.findServiceDescription(orgKey, config.serviceUri).flatMap {
           case None =>
             Sync[F].raiseError(OsciError.AgsNotInDvdv(ags, config.serviceUri))
@@ -30,7 +30,7 @@ object AgsResolver {
         }
       }
 
-      private def buildRoute(ags: String, elems: List[ServiceElementInfo]): F[OsciRoute] = {
+      private def buildRoute(ags: Ags, elems: List[ServiceElementInfo]): F[OsciRoute] = {
         def find(t: ServiceElementType): F[ServiceElementInfo] =
           elems.find(_.serviceElementType.contains(t)) match {
             case Some(e) => Sync[F].pure(e)
@@ -65,14 +65,14 @@ object AgsResolver {
         yield OsciRoute(addrUri, addrCipher, addrSig, intUri, intCipher)
       }
 
-      private def requireCipher(ags: String, kind: String, e: ServiceElementInfo): F[X509Certificate] =
+      private def requireCipher(ags: Ags, kind: String, e: ServiceElementInfo): F[X509Certificate] =
         requireCipherCert(ags, kind, e.cipherCertificate)
 
-      private def requireCipherCert(ags: String, kind: String, c: Option[DvdvCert]): F[X509Certificate] =
+      private def requireCipherCert(ags: Ags, kind: String, c: Option[DvdvCert]): F[X509Certificate] =
         c match {
           case Some(cert) => decodeCert(cert).adaptError(t => OsciError.Certificate(t))
           case None       => Sync[F].raiseError[X509Certificate](
-                               OsciError.RecipientCertMissing(s"$ags ($kind)")
+                               OsciError.RecipientCertMissing(ags, kind)
                              )
         }
 

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/FacadeImpl.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/FacadeImpl.scala
@@ -3,6 +3,7 @@ package de.thatscalaguy.zustellix.osci.internal
 import cats.Monad
 import cats.syntax.all.*
 import de.thatscalaguy.zustellix.osci.{
+  Ags,
   OsciFacade,
   OsciReceipt,
   OsciResponse,
@@ -13,9 +14,9 @@ import de.thatscalaguy.zustellix.osci.{
 private[osci] final class FacadeImpl[F[_]: Monad](registry: TenantRegistry[F])
     extends OsciFacade[F] {
 
-  def request(tenant: TenantId, ags: String, xml: String): F[OsciResponse] =
+  def request(tenant: TenantId, ags: Ags, xml: String): F[OsciResponse] =
     registry.lookup(tenant).flatMap(_.request(ags, xml))
 
-  def send(tenant: TenantId, ags: String, xml: String): F[OsciReceipt] =
+  def send(tenant: TenantId, ags: Ags, xml: String): F[OsciReceipt] =
     registry.lookup(tenant).flatMap(_.send(ags, xml))
 }

--- a/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
+++ b/osci/src/main/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImpl.scala
@@ -3,8 +3,10 @@ package de.thatscalaguy.zustellix.osci.internal
 import cats.effect.{Clock, Sync}
 import cats.syntax.all.*
 import de.thatscalaguy.zustellix.osci.{
+  Ags,
   Laufzettel,
   LaufzettelSink,
+  LaufzettelStatus,
   OsciClient,
   OsciError,
   OsciReceipt,
@@ -23,7 +25,7 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
     capturePayloads: Boolean = false
 ) extends OsciClient[F] {
 
-  def request(ags: String, xml: String): F[OsciResponse] =
+  def request(ags: Ags, xml: String): F[OsciResponse] =
     for {
       route  <- resolver.resolve(ags)
                   .onError { case e => recordFailure(ags, None, e) }
@@ -35,7 +37,7 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
                   timestamp    = now,
                   recipientAgs = ags,
                   recipientUri = route.addresseeUri,
-                  status       = result.status,
+                  status       = LaufzettelStatus.Feedback(result.status),
                   rawXml       = if capturePayloads then result.responseXml else None,
                   warnings     = result.warnings,
                   contentSignature = result.signature
@@ -49,7 +51,7 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
       warnings  = result.warnings
     )
 
-  def send(ags: String, xml: String): F[OsciReceipt] =
+  def send(ags: Ags, xml: String): F[OsciReceipt] =
     for {
       route   <- resolver.resolve(ags)
                    .onError { case e => recordFailure(ags, None, e) }
@@ -61,7 +63,7 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
                    timestamp    = now,
                    recipientAgs = ags,
                    recipientUri = route.addresseeUri,
-                   status       = receipt.status,
+                   status       = LaufzettelStatus.Feedback(receipt.status),
                    rawXml       = None, // async: no response payload at store time
                    warnings     = receipt.warnings
                  )
@@ -70,15 +72,15 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
     yield receipt
 
   /** Failed deliveries leave a Laufzettel too, so the audit trail is not
-   *  success-only: `status` carries the OSCI feedback code for a `9xxx`
-   *  response and the error kind otherwise, `messageId` the id from
-   *  `GetMessageId` when one was issued before the failure ("" otherwise),
+   *  success-only: `status` is `Feedback` with the OSCI code for a `9xxx`
+   *  response and `Failed` with the error kind otherwise, `messageId` the id
+   *  from `GetMessageId` when one was issued before the failure ("" otherwise),
    *  `rawXml` stays `None`. `recipientUri` is the resolved addressee URI, or
    *  empty when the resolver itself failed. Recording is best-effort — the
    *  original error is re-raised untouched, and a sink failure is swallowed
    *  like on the success path.
    */
-  private def recordFailure(ags: String, uri: Option[URI], e: Throwable): F[Unit] =
+  private def recordFailure(ags: Ags, uri: Option[URI], e: Throwable): F[Unit] =
     Clock[F].realTimeInstant.flatMap { now =>
       val lz = Laufzettel(
         messageId    = failureMessageId(e),
@@ -91,10 +93,10 @@ private[osci] final class OsciClientImpl[F[_]: Sync: Clock](
       sink.record(tenantId, lz).attempt.void
     }
 
-  private def failureStatus(e: Throwable): String =
+  private def failureStatus(e: Throwable): LaufzettelStatus =
     e match {
-      case OsciError.OsciResponse(code, _, _) => code
-      case other                              => other.getClass.getSimpleName
+      case OsciError.OsciResponse(code, _, _) => LaufzettelStatus.Feedback(code)
+      case other                              => LaufzettelStatus.Failed(other.getClass.getSimpleName)
     }
 
   private def failureMessageId(e: Throwable): String =

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/AgsSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/AgsSpec.scala
@@ -1,0 +1,38 @@
+package de.thatscalaguy.zustellix.osci
+
+import munit.FunSuite
+
+class AgsSpec extends FunSuite {
+
+  test("from accepts exactly 8 digits, keeping leading zeros") {
+    assertEquals(Ags.from("01001000").map(_.value), Right("01001000"))
+    assertEquals(Ags.from("99999999").map(_.value), Right("99999999"))
+    assertEquals(Ags.from("00000000").map(_.value), Right("00000000"))
+  }
+
+  test("from rejects the wrong length") {
+    assert(Ags.from("").isLeft)
+    assert(Ags.from("0100100").isLeft)
+    assert(Ags.from("010010001").isLeft)
+  }
+
+  test("from rejects non-digit characters") {
+    assert(Ags.from("0100100a").isLeft)
+    assert(Ags.from("01 01000").isLeft)
+    assert(Ags.from("-1001000").isLeft)
+    // Unicode digits are not ASCII digits
+    assert(Ags.from("٠١٢٣٤٥٦٧").isLeft)
+  }
+
+  test("from reports the rejected input as InvalidAgs") {
+    Ags.from("nope") match {
+      case Left(e: OsciError.InvalidAgs) => assertEquals(e.input, "nope")
+      case other                         => fail(s"unexpected: $other")
+    }
+  }
+
+  test("unsafe returns the Ags for valid input and throws InvalidAgs otherwise") {
+    assertEquals(Ags.unsafe("01001000").value, "01001000")
+    intercept[OsciError.InvalidAgs](Ags.unsafe("123"))
+  }
+}

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/LaufzettelSinkSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/LaufzettelSinkSpec.scala
@@ -11,9 +11,9 @@ class LaufzettelSinkSpec extends CatsEffectSuite {
   private val sampleLz = Laufzettel(
     messageId    = "msg-1",
     timestamp    = Instant.parse("2026-05-13T12:00:00Z"),
-    recipientAgs = "01001000",
+    recipientAgs = Ags.unsafe("01001000"),
     recipientUri = URI.create("https://example/osci"),
-    status       = "OK",
+    status       = LaufzettelStatus.Feedback("0800"),
     rawXml       = Some("<x/>")
   )
 

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/LaufzettelStatusSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/LaufzettelStatusSpec.scala
@@ -1,0 +1,21 @@
+package de.thatscalaguy.zustellix.osci
+
+import munit.FunSuite
+
+class LaufzettelStatusSpec extends FunSuite {
+
+  test("0xxx and 3xxx feedback counts as delivered") {
+    assert(LaufzettelStatus.Feedback("0800").delivered)
+    assert(LaufzettelStatus.Feedback("3802").delivered)
+  }
+
+  test("9xxx feedback and Failed records are not delivered") {
+    assert(!LaufzettelStatus.Feedback("9000").delivered)
+    assert(!LaufzettelStatus.Failed("OsciTransport").delivered)
+  }
+
+  test("render yields the plain code or error kind") {
+    assertEquals(LaufzettelStatus.Feedback("0800").render, "0800")
+    assertEquals(LaufzettelStatus.Failed("AgsNotInDvdv").render, "AgsNotInDvdv")
+  }
+}

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/OsciErrorSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/OsciErrorSpec.scala
@@ -11,15 +11,24 @@ class OsciErrorSpec extends FunSuite {
     assert(e.getMessage.contains("alice"))
   }
 
+  test("InvalidAgs message includes the rejected input") {
+    val e = OsciError.InvalidAgs("123")
+    assert(e.getMessage.contains("123"))
+    assert(e.getMessage.contains("8 digits"))
+  }
+
   test("AgsNotInDvdv message includes the AGS and service URI") {
-    val e = OsciError.AgsNotInDvdv("01001000", "http://example/wsdl")
+    val e = OsciError.AgsNotInDvdv(Ags.unsafe("01001000"), "http://example/wsdl")
     assert(e.getMessage.contains("01001000"))
     assert(e.getMessage.contains("http://example/wsdl"))
   }
 
-  test("RecipientCertMissing message includes the AGS") {
-    val e = OsciError.RecipientCertMissing("01001000")
+  test("RecipientCertMissing message includes the AGS and the element kind") {
+    val e = OsciError.RecipientCertMissing(Ags.unsafe("01001000"), "OSCI_ADDRESSEE")
     assert(e.getMessage.contains("01001000"))
+    assert(e.getMessage.contains("OSCI_ADDRESSEE"))
+    assertEquals(e.ags, Ags.unsafe("01001000"))
+    assertEquals(e.kind, "OSCI_ADDRESSEE")
   }
 
   test("OsciTransport preserves the cause") {
@@ -62,8 +71,9 @@ class OsciErrorSpec extends FunSuite {
   test("All variants are OsciError subtypes") {
     val errs: List[OsciError] = List(
       OsciError.UnknownTenant(TenantId("x")),
-      OsciError.AgsNotInDvdv("a", "u"),
-      OsciError.RecipientCertMissing("a"),
+      OsciError.InvalidAgs("x"),
+      OsciError.AgsNotInDvdv(Ags.unsafe("01001000"), "u"),
+      OsciError.RecipientCertMissing(Ags.unsafe("01001000"), "OSCI_ADDRESSEE"),
       OsciError.OsciTransport(new IOException("x")),
       OsciError.OsciResponse("c", "d"),
       OsciError.NoSuchMessage("m"),

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/TenantRegistrySpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/TenantRegistrySpec.scala
@@ -6,9 +6,9 @@ import munit.CatsEffectSuite
 class TenantRegistrySpec extends CatsEffectSuite {
 
   private def fakeClient(tag: String): OsciClient[IO] = new OsciClient[IO] {
-    def request(ags: String, xml: String): IO[OsciResponse] =
-      IO.pure(OsciResponse(Some(s"$tag:$ags"), s"$tag-msg", "0800"))
-    def send(ags: String, xml: String): IO[OsciReceipt] =
+    def request(ags: Ags, xml: String): IO[OsciResponse] =
+      IO.pure(OsciResponse(Some(s"$tag:${ags.value}"), s"$tag-msg", "0800"))
+    def send(ags: Ags, xml: String): IO[OsciReceipt] =
       IO.pure(OsciReceipt(s"$tag-msg", "0800", None))
   }
 
@@ -16,9 +16,9 @@ class TenantRegistrySpec extends CatsEffectSuite {
     val alice = fakeClient("alice")
     val reg   = TenantRegistry.inMemory[IO](Map(TenantId("alice") -> alice))
     reg.lookup(TenantId("alice"))
-      .flatMap(_.request("01", "x"))
+      .flatMap(_.request(Ags.unsafe("01001000"), "x"))
       .map(_.xml)
-      .assertEquals(Some("alice:01"))
+      .assertEquals(Some("alice:01001000"))
   }
 
   test("inMemory.lookup raises UnknownTenant on miss") {

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/AgsResolverSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/AgsResolverSpec.scala
@@ -13,6 +13,8 @@ import java.util.Base64
 
 class AgsResolverSpec extends CatsEffectSuite {
 
+  private val TestAgs = Ags.unsafe("01001000")
+
   private val Cfg = OsciConfig(
     tenantId   = TenantId("t"),
     certSource = Some(CertSource.Pkcs12(Paths.get("k.p12"), "pw"))
@@ -102,7 +104,7 @@ class AgsResolverSpec extends CatsEffectSuite {
         ))))
       case other => IO.raiseError(new AssertionError(s"unexpected: $other"))
     }
-    AgsResolver[IO](dvdv, Cfg).resolve("01001000").map { route =>
+    AgsResolver[IO](dvdv, Cfg).resolve(TestAgs).map { route =>
       assertEquals(route.addresseeUri.toString, "https://recipient/osci")
       assertEquals(route.intermedUri.toString,  "https://intermed/osci")
       assert(route.addresseeCipher != null)
@@ -112,10 +114,11 @@ class AgsResolverSpec extends CatsEffectSuite {
   }
 
   test("resolve raises AgsNotInDvdv when DVDV returns None") {
-    val dvdv = stubDvdv((_, _) => IO.pure(None))
-    AgsResolver[IO](dvdv, Cfg).resolve("nope").attempt.map {
-      case Left(OsciError.AgsNotInDvdv("nope", _)) => ()
-      case other                                        => fail(s"unexpected: $other")
+    val unknown = Ags.unsafe("99999999")
+    val dvdv    = stubDvdv((_, _) => IO.pure(None))
+    AgsResolver[IO](dvdv, Cfg).resolve(unknown).attempt.map {
+      case Left(OsciError.AgsNotInDvdv(ags, _)) => assertEquals(ags, unknown)
+      case other                                     => fail(s"unexpected: $other")
     }
   }
 
@@ -123,9 +126,9 @@ class AgsResolverSpec extends CatsEffectSuite {
     val dvdv = stubDvdv((_, _) => IO.pure(Some(serviceWithElements(List(
       element(ServiceElementType.OSCI_ADDRESSEE, "https://recipient/osci", Some(testCertB64))
     )))))
-    AgsResolver[IO](dvdv, Cfg).resolve("01001000").attempt.map {
-      case Left(OsciError.ServiceElementMissing("01001000", "OSCI_INTERMEDIARY")) => ()
-      case other                                                                       => fail(s"unexpected: $other")
+    AgsResolver[IO](dvdv, Cfg).resolve(TestAgs).attempt.map {
+      case Left(OsciError.ServiceElementMissing(TestAgs, "OSCI_INTERMEDIARY")) => ()
+      case other                                                                    => fail(s"unexpected: $other")
     }
   }
 
@@ -134,9 +137,10 @@ class AgsResolverSpec extends CatsEffectSuite {
       element(ServiceElementType.OSCI_ADDRESSEE,    "https://recipient/osci", None),
       element(ServiceElementType.OSCI_INTERMEDIARY, "https://intermed/osci",  Some(testCertB64))
     )))))
-    AgsResolver[IO](dvdv, Cfg).resolve("01001000").attempt.map {
+    AgsResolver[IO](dvdv, Cfg).resolve(TestAgs).attempt.map {
       case Left(e: OsciError.RecipientCertMissing) =>
-        assert(e.ags.startsWith("01001000"))
+        assertEquals(e.ags, TestAgs)
+        assertEquals(e.kind, "OSCI_ADDRESSEE")
       case other => fail(s"unexpected: $other")
     }
   }
@@ -147,7 +151,7 @@ class AgsResolverSpec extends CatsEffectSuite {
       element(ServiceElementType.OSCI_INTERMEDIARY,  "https://intermed/osci",  Some(testCertB64),  name = Some("intm")),
       element(ServiceElementType.CIPHER_CERTIFICATE, "https://other/cipher",   Some(otherCertB64), name = Some("intm"))
     )))))
-    AgsResolver[IO](dvdv, Cfg).resolve("01001000").map { route =>
+    AgsResolver[IO](dvdv, Cfg).resolve(TestAgs).map { route =>
       assert(route.addresseeCipher.getEncoded.sameElements(certBytes(testCertB64)),
              "addressee cipher must be the inline cert, not the foreign standalone one")
     }
@@ -159,7 +163,7 @@ class AgsResolverSpec extends CatsEffectSuite {
       element(ServiceElementType.OSCI_INTERMEDIARY,  "https://intermed/osci",  Some(testCertB64),  name = Some("intm")),
       element(ServiceElementType.CIPHER_CERTIFICATE, "https://addr/cipher",    Some(otherCertB64), name = Some("addr"))
     )))))
-    AgsResolver[IO](dvdv, Cfg).resolve("01001000").map { route =>
+    AgsResolver[IO](dvdv, Cfg).resolve(TestAgs).map { route =>
       assert(route.addresseeCipher.getEncoded.sameElements(certBytes(otherCertB64)),
              "addressee cipher must be the matching standalone cert")
     }
@@ -171,9 +175,10 @@ class AgsResolverSpec extends CatsEffectSuite {
       element(ServiceElementType.OSCI_INTERMEDIARY,  "https://intermed/osci",  Some(testCertB64),  name = Some("intm")),
       element(ServiceElementType.CIPHER_CERTIFICATE, "https://other/cipher",   Some(otherCertB64), name = Some("intm"))
     )))))
-    AgsResolver[IO](dvdv, Cfg).resolve("01001000").attempt.map {
+    AgsResolver[IO](dvdv, Cfg).resolve(TestAgs).attempt.map {
       case Left(e: OsciError.RecipientCertMissing) =>
-        assert(e.ags.startsWith("01001000"))
+        assertEquals(e.ags, TestAgs)
+        assertEquals(e.kind, "OSCI_ADDRESSEE")
       case other => fail(s"unexpected: $other")
     }
   }

--- a/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
+++ b/osci/src/test/scala/de/thatscalaguy/zustellix/osci/internal/OsciClientImplSpec.scala
@@ -9,7 +9,8 @@ import java.security.cert.X509Certificate
 
 class OsciClientImplSpec extends CatsEffectSuite {
 
-  private val Ags = "01001000"
+  private val TestAgs = Ags.unsafe("01001000")
+  private val NopeAgs = Ags.unsafe("99999999")
 
   // The impl never inspects the certs; they're threaded through to the
   // transport. Null references are sufficient for these tests.
@@ -22,11 +23,11 @@ class OsciClientImplSpec extends CatsEffectSuite {
   )
 
   private def fixedResolver(route: OsciRoute): AgsResolver[IO] = new AgsResolver[IO] {
-    def resolve(ags: String): IO[OsciRoute] = IO.pure(route)
+    def resolve(ags: Ags): IO[OsciRoute] = IO.pure(route)
   }
 
   private def failingResolver(err: Throwable): AgsResolver[IO] = new AgsResolver[IO] {
-    def resolve(ags: String): IO[OsciRoute] = IO.raiseError(err)
+    def resolve(ags: Ags): IO[OsciRoute] = IO.raiseError(err)
   }
 
   private def fixedTransport(out: OsciRawResult): OsciTransport[IO] = new OsciTransport[IO] {
@@ -67,15 +68,15 @@ class OsciClientImplSpec extends CatsEffectSuite {
         recordingSink(ref)
       )
       for {
-        out  <- impl.request(Ags, "<req/>")
+        out  <- impl.request(TestAgs, "<req/>")
         seen <- ref.get
       }
       yield {
         assertEquals(out, OsciResponse(Some("<resp/>"), "msg-1", "OK"))
         assertEquals(seen.size, 1)
         assertEquals(seen.head.messageId, "msg-1")
-        assertEquals(seen.head.recipientAgs, Ags)
-        assertEquals(seen.head.status, "OK")
+        assertEquals(seen.head.recipientAgs, TestAgs)
+        assertEquals(seen.head.status, LaufzettelStatus.Feedback("OK"))
         assertEquals(seen.head.rawXml, None)
       }
     }
@@ -93,7 +94,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
         capturePayloads = true
       )
       for {
-        _    <- impl.request(Ags, "<req/>")
+        _    <- impl.request(TestAgs, "<req/>")
         seen <- ref.get
       }
       yield assertEquals(seen.head.rawXml, Some("<resp/>"))
@@ -112,7 +113,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
         capturePayloads = true
       )
       for {
-        _    <- impl.request(Ags, "<req/>")
+        _    <- impl.request(TestAgs, "<req/>")
         seen <- ref.get
       }
       yield assertEquals(seen.head.rawXml, None)
@@ -130,7 +131,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
         recordingSink(ref)
       )
       for {
-        out  <- impl.request(Ags, "<req/>")
+        out  <- impl.request(TestAgs, "<req/>")
         seen <- ref.get
       }
       yield {
@@ -152,12 +153,12 @@ class OsciClientImplSpec extends CatsEffectSuite {
         recordingSink(ref)
       )
       for {
-        out  <- impl.request(Ags, "<req/>")
+        out  <- impl.request(TestAgs, "<req/>")
         seen <- ref.get
       }
       yield {
         assertEquals(out, OsciResponse(Some("<resp/>"), "msg-1", "3802", List(warning)))
-        assertEquals(seen.head.status, "3802")
+        assertEquals(seen.head.status, LaufzettelStatus.Feedback("3802"))
         assertEquals(seen.head.warnings, List(warning))
       }
     }
@@ -176,7 +177,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
         recordingSink(ref)
       )
       for {
-        _    <- impl.request(Ags, "<req/>")
+        _    <- impl.request(TestAgs, "<req/>")
         seen <- ref.get
       }
       yield assertEquals(seen.head.contentSignature, Some(ContentSignatureStatus.Unsigned))
@@ -194,13 +195,13 @@ class OsciClientImplSpec extends CatsEffectSuite {
         recordingSink(ref)
       )
       for {
-        out  <- impl.request(Ags, "<req/>").attempt
+        out  <- impl.request(TestAgs, "<req/>").attempt
         seen <- ref.get
       }
       yield {
         assertEquals(out, Left(err))
         assertEquals(seen.head.messageId, "msg-u")
-        assertEquals(seen.head.status, "UnsignedContent")
+        assertEquals(seen.head.status, LaufzettelStatus.Failed("UnsignedContent"))
         assertEquals(seen.head.contentSignature, None)
       }
     }
@@ -217,16 +218,16 @@ class OsciClientImplSpec extends CatsEffectSuite {
         recordingSink(ref)
       )
       for {
-        out  <- impl.request(Ags, "<req/>").attempt
+        out  <- impl.request(TestAgs, "<req/>").attempt
         seen <- ref.get
       }
       yield {
         assertEquals(out, Left(err))
         assertEquals(seen.size, 1)
         assertEquals(seen.head.messageId, "msg-9")
-        assertEquals(seen.head.recipientAgs, Ags)
+        assertEquals(seen.head.recipientAgs, TestAgs)
         assertEquals(seen.head.recipientUri, Route.addresseeUri)
-        assertEquals(seen.head.status, "9000")
+        assertEquals(seen.head.status, LaufzettelStatus.Feedback("9000"))
         assertEquals(seen.head.rawXml, None)
         assertEquals(seen.head.warnings, Nil)
       }
@@ -244,21 +245,21 @@ class OsciClientImplSpec extends CatsEffectSuite {
         recordingSink(ref)
       )
       for {
-        out  <- impl.request(Ags, "<req/>").attempt
+        out  <- impl.request(TestAgs, "<req/>").attempt
         seen <- ref.get
       }
       yield {
         assertEquals(out, Left(err))
         assertEquals(seen.size, 1)
         assertEquals(seen.head.messageId, "")
-        assertEquals(seen.head.status, "OsciTransport")
+        assertEquals(seen.head.status, LaufzettelStatus.Failed("OsciTransport"))
         assertEquals(seen.head.rawXml, None)
       }
     }
   }
 
   test("request: a resolver failure records a failure Laufzettel without a recipient URI") {
-    val err = OsciError.AgsNotInDvdv("nope", "u")
+    val err = OsciError.AgsNotInDvdv(NopeAgs, "u")
     Ref.of[IO, Vector[Laufzettel]](Vector.empty).flatMap { ref =>
       val impl = new OsciClientImpl[IO](
         TenantId("alice"),
@@ -268,15 +269,15 @@ class OsciClientImplSpec extends CatsEffectSuite {
         recordingSink(ref)
       )
       for {
-        out  <- impl.request("nope", "<x/>").attempt
+        out  <- impl.request(NopeAgs, "<x/>").attempt
         seen <- ref.get
       }
       yield {
         assertEquals(out, Left(err))
         assertEquals(seen.size, 1)
-        assertEquals(seen.head.recipientAgs, "nope")
+        assertEquals(seen.head.recipientAgs, NopeAgs)
         assertEquals(seen.head.recipientUri, URI.create(""))
-        assertEquals(seen.head.status, "AgsNotInDvdv")
+        assertEquals(seen.head.status, LaufzettelStatus.Failed("AgsNotInDvdv"))
         assertEquals(seen.head.messageId, "")
       }
     }
@@ -291,7 +292,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
       fixedResolver(Route),
       failingSink
     )
-    impl.request(Ags, "<x/>").attempt.map {
+    impl.request(TestAgs, "<x/>").attempt.map {
       case Left(e: OsciError.OsciTransport) => assertEquals(e.getCause.getMessage, "net")
       case other                            => fail(s"unexpected: $other")
     }
@@ -302,12 +303,12 @@ class OsciClientImplSpec extends CatsEffectSuite {
       TenantId("alice"),
       "XMeld",
       fixedTransport(OsciRawResult(Some("<x/>"), "m", "OK")),
-      failingResolver(OsciError.AgsNotInDvdv("nope", "u")),
+      failingResolver(OsciError.AgsNotInDvdv(NopeAgs, "u")),
       LaufzettelSink.noop[IO]
     )
-    impl.request("nope", "<x/>").attempt.map {
-      case Left(OsciError.AgsNotInDvdv("nope", "u")) => ()
-      case other                                          => fail(s"unexpected: $other")
+    impl.request(NopeAgs, "<x/>").attempt.map {
+      case Left(OsciError.AgsNotInDvdv(NopeAgs, "u")) => ()
+      case other                                           => fail(s"unexpected: $other")
     }
   }
 
@@ -320,7 +321,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
       fixedResolver(Route),
       LaufzettelSink.noop[IO]
     )
-    impl.request(Ags, "<x/>").attempt.map {
+    impl.request(TestAgs, "<x/>").attempt.map {
       case Left(e: OsciError.OsciTransport) => assertEquals(e.getCause.getMessage, "net")
       case other                                 => fail(s"unexpected: $other")
     }
@@ -335,7 +336,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
       fixedResolver(Route),
       failingSink
     )
-    impl.request(Ags, "<req/>").assertEquals(OsciResponse(Some("<resp/>"), "m", "OK"))
+    impl.request(TestAgs, "<req/>").assertEquals(OsciResponse(Some("<resp/>"), "m", "OK"))
   }
 
   test("send happy path returns the receipt and records a Laufzettel without payload") {
@@ -349,15 +350,15 @@ class OsciClientImplSpec extends CatsEffectSuite {
         recordingSink(ref)
       )
       for {
-        out  <- impl.send(Ags, "<req/>")
+        out  <- impl.send(TestAgs, "<req/>")
         seen <- ref.get
       }
       yield {
         assertEquals(out, receipt)
         assertEquals(seen.size, 1)
         assertEquals(seen.head.messageId, "msg-2")
-        assertEquals(seen.head.recipientAgs, Ags)
-        assertEquals(seen.head.status, "0800")
+        assertEquals(seen.head.recipientAgs, TestAgs)
+        assertEquals(seen.head.status, LaufzettelStatus.Feedback("0800"))
         assertEquals(seen.head.rawXml, None)
       }
     }
@@ -372,7 +373,7 @@ class OsciClientImplSpec extends CatsEffectSuite {
       fixedResolver(Route),
       LaufzettelSink.noop[IO]
     )
-    impl.send(Ags, "<x/>").attempt.map {
+    impl.send(TestAgs, "<x/>").attempt.map {
       case Left(e: OsciError.OsciTransport) => assertEquals(e.getCause.getMessage, "net")
       case other                            => fail(s"unexpected: $other")
     }
@@ -389,16 +390,16 @@ class OsciClientImplSpec extends CatsEffectSuite {
         recordingSink(ref)
       )
       for {
-        out  <- impl.send(Ags, "<req/>").attempt
+        out  <- impl.send(TestAgs, "<req/>").attempt
         seen <- ref.get
       }
       yield {
         assertEquals(out, Left(err))
         assertEquals(seen.size, 1)
         assertEquals(seen.head.messageId, "msg-3")
-        assertEquals(seen.head.recipientAgs, Ags)
+        assertEquals(seen.head.recipientAgs, TestAgs)
         assertEquals(seen.head.recipientUri, Route.addresseeUri)
-        assertEquals(seen.head.status, "9802")
+        assertEquals(seen.head.status, LaufzettelStatus.Feedback("9802"))
         assertEquals(seen.head.rawXml, None)
       }
     }
@@ -413,6 +414,6 @@ class OsciClientImplSpec extends CatsEffectSuite {
       fixedResolver(Route),
       failingSink
     )
-    impl.send(Ags, "<req/>").assertEquals(receipt)
+    impl.send(TestAgs, "<req/>").assertEquals(receipt)
   }
 }


### PR DESCRIPTION
Closes #19.

Binary breaking, targeted at v0.4.0.

## What changed

**Opaque type `Ags`** (`osci/Ags.scala`)
- An AGS only exists via smart constructors: `Ags.from(s)` validates exactly 8 ASCII digits and returns `Either[OsciError.InvalidAgs, Ags]`; `Ags.unsafe(s)` throws for literals. `.value` reads the raw string back.
- Used in `OsciClient.request` / `send`, `OsciFacade.request` / `send`, `AgsResolver.resolve`, `Laufzettel.recipientAgs` and the `ags` field of `AgsNotInDvdv`, `RecipientCertMissing` and `ServiceElementMissing`. A typo now fails at the call site instead of turning into a DVDV miss.
- New error `OsciError.InvalidAgs(input)` for rejected input.

**`RecipientCertMissing` carries the element kind in its own field**
- Was `RecipientCertMissing(s"$ags ($kind)")` — two values packed into one string, which forced the tests to use `startsWith`. Now `RecipientCertMissing(ags: Ags, kind: String)`, with the kind (`OSCI_ADDRESSEE` / `OSCI_INTERMEDIARY`) still visible in the message. The tests assert both fields exactly.

**Typed status on the Laufzettel**
- `Laufzettel.status` is now a `LaufzettelStatus` instead of a `String`:
  - `Feedback(code)` — the top OSCI feedback code (`0xxx` / `3xxx` / `9xxx`),
  - `Failed(kind)` — the error kind when the delivery failed before any feedback code existed (e.g. `OsciTransport`, `AgsNotInDvdv`).
- `status.delivered` expresses the "`0xxx` / `3xxx` = executed" rule directly; `status.render` yields the previous plain string for logs and DB columns. The console sink prints `render`.

`OsciResponse.status` and `OsciReceipt.status` stay plain feedback-code strings; only the Laufzettel record gets the wrapper.

The README migration notes, examples and error table are updated accordingly.