### PR TITLE
dvdv: resolve signing cert on every token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,12 @@ DvdvClient.fromClient[IO](config, myClient)
 DvdvClient.fromClient[IO](config, myClient, certManager, CertAlias("kiel"))
 ```
 
+On the `CertManager` overloads the alias is resolved once at build time (so an
+unknown alias fails fast) and then again on every token refresh — a cert
+rotated in the manager (e.g. by `DirectoryCertManager`) signs the next
+`client_assertion` without a restart. The `certSource` constructors load the
+cert once and keep it for the lifetime of the client.
+
 ### Configuration
 
 ```scala

--- a/dvdv/src/main/scala/de/thatscalaguy/zustellix/dvdv/DvdvClient.scala
+++ b/dvdv/src/main/scala/de/thatscalaguy/zustellix/dvdv/DvdvClient.scala
@@ -56,12 +56,16 @@ object DvdvClient {
     for {
       loaded <- Resource.eval(loadConfigured[F](config))
       http   <- EmberClientBuilder.default[F].withTimeout(config.requestTimeout).build
-      client <- assemble[F](config, http, loaded)
+      client <- assemble[F](config, http, Async[F].pure(loaded))
     } yield client
 
   /** Build a DvdvClient whose signing cert is resolved from the shared
    *  [[CertManager]] by [[CertAlias]] (the cert signs the `client_assertion`
    *  JWT, so a client is scoped to one alias).
+   *
+   *  The alias is resolved once at build time to fail fast on a missing cert,
+   *  and again on every token refresh — so a cert rotated in the manager (e.g.
+   *  a hot-reloading `DirectoryCertManager`) is picked up without a restart.
    */
   def resource[F[_]: Async: Network](
       config: DvdvConfig,
@@ -69,25 +73,28 @@ object DvdvClient {
       alias:  CertAlias
   ): Resource[F, DvdvClient[F]] =
     for {
-      loaded <- Resource.eval(certs.loadedCert(alias))
+      _      <- Resource.eval(certs.loadedCert(alias))
       http   <- EmberClientBuilder.default[F].withTimeout(config.requestTimeout).build
-      client <- assemble[F](config, http, loaded)
+      client <- assemble[F](config, http, certs.loadedCert(alias))
     } yield client
 
   /** Build a DvdvClient over a caller-provided http4s Client.
    *  Useful for testing or when the caller wants to control the HTTP backend.
    */
   def fromClient[F[_]: Async](config: DvdvConfig, http: Client[F]): Resource[F, DvdvClient[F]] =
-    Resource.eval(loadConfigured[F](config)).flatMap(assemble[F](config, http, _))
+    Resource.eval(loadConfigured[F](config)).flatMap(loaded => assemble[F](config, http, Async[F].pure(loaded)))
 
-  /** [[fromClient]] with the signing cert resolved by [[CertAlias]]. */
+  /** [[fromClient]] with the signing cert resolved by [[CertAlias]]. Like the
+   *  [[resource]] overload, the cert is re-resolved on every token refresh so
+   *  rotations in the [[CertManager]] take effect without a rebuild.
+   */
   def fromClient[F[_]: Async](
       config: DvdvConfig,
       http:   Client[F],
       certs:  CertManager[F],
       alias:  CertAlias
   ): Resource[F, DvdvClient[F]] =
-    Resource.eval(certs.loadedCert(alias)).flatMap(assemble[F](config, http, _))
+    Resource.eval(certs.loadedCert(alias)).flatMap(_ => assemble[F](config, http, certs.loadedCert(alias)))
 
   private def loadConfigured[F[_]: Sync](config: DvdvConfig): F[LoadedCert] =
     config.certSource match {
@@ -101,13 +108,13 @@ object DvdvClient {
     }
 
   private def assemble[F[_]: Async](
-      config: DvdvConfig,
-      http:   Client[F],
-      loaded: LoadedCert
+      config:  DvdvConfig,
+      http:    Client[F],
+      resolve: F[LoadedCert]
   ): Resource[F, DvdvClient[F]] =
     for {
       failover <- Resource.eval(FailoverClient.make[F](config.servers, config.recoverAfter)).map(_(http))
-      tokenMgr <- Resource.eval(TokenManager.make[F](failover, config, loaded))
+      tokenMgr <- Resource.eval(TokenManager.make[F](failover, config, resolve))
       authed    = AuthMiddleware(tokenMgr)(failover)
       raw       = HttpDvdvClient[F](authed, config)
       cached   <- Resource.eval(CachedDvdvClient.make[F](raw, config.cacheConfig))

--- a/dvdv/src/main/scala/de/thatscalaguy/zustellix/dvdv/auth/TokenManager.scala
+++ b/dvdv/src/main/scala/de/thatscalaguy/zustellix/dvdv/auth/TokenManager.scala
@@ -24,20 +24,25 @@ object TokenManager {
 
   private final case class CachedToken(value: String, notAfter: Instant)
 
+  /** `resolve` is evaluated on every token acquisition (once per refresh, cheap),
+   *  so a rotated signing cert — e.g. from a hot-reloading `CertManager` — is
+   *  picked up without rebuilding the client. Pass a pure/memoized value for a
+   *  cert that is fixed for the lifetime of the manager.
+   */
   def make[F[_]: Async](
       client: Client[F],
       config: DvdvConfig,
-      loaded: LoadedCert
+      resolve: F[LoadedCert]
   ): F[TokenManager[F]] =
     for {
       ref   <- Ref.of[F, Option[CachedToken]](None)
       mutex <- Mutex[F]
-    } yield new Impl[F](client, config, loaded, ref, mutex)
+    } yield new Impl[F](client, config, resolve, ref, mutex)
 
   private final class Impl[F[_]: Async](
       client: Client[F],
       config: DvdvConfig,
-      loaded: LoadedCert,
+      resolve: F[LoadedCert],
       state: Ref[F, Option[CachedToken]],
       mutex: Mutex[F]
   ) extends TokenManager[F] {
@@ -71,7 +76,8 @@ object TokenManager {
 
     private def acquire(now: Instant): F[CachedToken] =
       for {
-        jwt <- JwtFactory.make[F](config, loaded)
+        loaded <- resolve
+        jwt    <- JwtFactory.make[F](config, loaded)
         form = UrlForm(
                  "grant_type"            -> "client_credentials",
                  "client_assertion_type" -> "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",

--- a/dvdv/src/test/scala/de/thatscalaguy/zustellix/dvdv/DvdvClientSpec.scala
+++ b/dvdv/src/test/scala/de/thatscalaguy/zustellix/dvdv/DvdvClientSpec.scala
@@ -1,11 +1,23 @@
 package de.thatscalaguy.zustellix.dvdv
 
-import cats.effect.IO
-import de.thatscalaguy.zustellix.utils.cert.CertSource
+import cats.effect.{IO, Ref}
+import cats.syntax.all.*
+import de.thatscalaguy.zustellix.utils.cert.{
+  CertAlias,
+  CertCredential,
+  CertLoader,
+  CertManagerError,
+  CertSource,
+  InMemoryCertManager
+}
+import io.circe.Json
 import munit.CatsEffectSuite
-import org.http4s.HttpApp
+import org.http4s.*
+import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
 import org.http4s.client.Client
+import org.http4s.dsl.io.*
 import org.http4s.implicits.uri
+import pdi.jwt.{JwtCirce, JwtOptions}
 
 import java.nio.file.Paths
 
@@ -36,5 +48,53 @@ class DvdvClientSpec extends CatsEffectSuite {
             )
       _ <- DvdvClient.fromClient[IO](cfg, http).use_
     } yield ()
+  }
+
+  test("fromClient with a CertManager fails fast on an unknown alias") {
+    for {
+      certs <- InMemoryCertManager.make[IO](Map.empty[CertAlias, CertCredential])
+      res   <- DvdvClient
+                 .fromClient[IO](DvdvConfig(baseUri = uri"http://dvdv.test"), http, certs, CertAlias("nope"))
+                 .use_
+                 .attempt
+    } yield res match {
+      case Left(CertManagerError.UnknownCert(a)) => assertEquals(a, CertAlias("nope"))
+      case other                                 => fail(s"expected UnknownCert, got $other")
+    }
+  }
+
+  test("fromClient with a CertManager signs with the rotated cert after a swap") {
+    val alias = CertAlias("tenant")
+    for {
+      oldP12   <- TestCerts.mintP12("old")
+      newP12   <- TestCerts.mintP12("new")
+      oldFp    <- CertLoader.loadPkcs12Bytes[IO](oldP12, TestCerts.password).map(_.fingerprintSha1Hex)
+      newFp    <- CertLoader.loadPkcs12Bytes[IO](newP12, TestCerts.password).map(_.fingerprintSha1Hex)
+      subjects <- Ref.of[IO, List[String]](Nil)
+      routes = HttpRoutes.of[IO] {
+                 case req @ POST -> Root / "extern" / "standaloneauth" / "token" =>
+                   for {
+                     form <- req.as[UrlForm]
+                     jwt   = form.values.get("client_assertion").flatMap(_.headOption).getOrElse("")
+                     sub   = JwtCirce.decode(jwt, JwtOptions(signature = false)).toOption.flatMap(_.subject).getOrElse("")
+                     _    <- subjects.update(_ :+ sub)
+                     resp <- Ok(Json.obj(
+                               "access_token" -> Json.fromString("tok"),
+                               "expires_in"   -> Json.fromLong(0L), // expire at once → refresh on every call
+                               "token_type"   -> Json.fromString("Bearer")
+                             ))
+                   } yield resp
+                 case GET -> Root / "extern" / "standaloneauth" / "directory" / "v2" / "version" =>
+                   Ok(Json.fromString("v1"))
+               }
+      certs <- InMemoryCertManager.make[IO](Map(alias -> CertCredential(oldP12, TestCerts.password)))
+      cfg    = DvdvConfig(baseUri = uri"http://dvdv.test")
+      _     <- DvdvClient.fromClient[IO](cfg, Client.fromHttpApp(routes.orNotFound), certs, alias).use { dvdv =>
+                 dvdv.serviceVersion *>
+                   certs.swap(Map(alias -> CertCredential(newP12, TestCerts.password))) *>
+                   dvdv.serviceVersion.void
+               }
+      subs  <- subjects.get
+    } yield assertEquals(subs, List(s"fp:$oldFp", s"fp:$newFp"))
   }
 }

--- a/dvdv/src/test/scala/de/thatscalaguy/zustellix/dvdv/TestCerts.scala
+++ b/dvdv/src/test/scala/de/thatscalaguy/zustellix/dvdv/TestCerts.scala
@@ -1,0 +1,43 @@
+package de.thatscalaguy.zustellix.dvdv
+
+import cats.effect.IO
+import de.thatscalaguy.zustellix.utils.cert.{CertLoader, LoadedCert}
+
+import java.io.ByteArrayOutputStream
+import java.math.BigInteger
+import java.security.KeyStore
+import java.util.Date
+
+/** Mints throw-away self-signed RSA PKCS12 keystores, so rotation tests can
+ *  produce a second signing cert distinct from the checked-in `test-cert.p12`.
+ */
+object TestCerts {
+
+  java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider())
+
+  val password = "pw"
+
+  def mintP12(cn: String): IO[Array[Byte]] = IO.blocking {
+    val kpg = java.security.KeyPairGenerator.getInstance("RSA")
+    kpg.initialize(2048)
+    val kp    = kpg.generateKeyPair()
+    val name  = new javax.security.auth.x500.X500Principal(s"CN=$cn")
+    val now   = new Date()
+    val later = new Date(now.getTime + 86400000L)
+    val builder = new org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder(
+      name, BigInteger.valueOf(System.nanoTime()), now, later, name, kp.getPublic
+    )
+    val signer = new org.bouncycastle.operator.jcajce.JcaContentSignerBuilder("SHA256withRSA").build(kp.getPrivate)
+    val cert   = new org.bouncycastle.cert.jcajce.JcaX509CertificateConverter().getCertificate(builder.build(signer))
+
+    val ks = KeyStore.getInstance("PKCS12")
+    ks.load(null, null)
+    ks.setKeyEntry(cn, kp.getPrivate, password.toCharArray, Array(cert))
+    val out = new ByteArrayOutputStream()
+    ks.store(out, password.toCharArray)
+    out.toByteArray
+  }
+
+  def mintLoadedCert(cn: String): IO[LoadedCert] =
+    mintP12(cn).flatMap(CertLoader.loadPkcs12Bytes[IO](_, password))
+}

--- a/dvdv/src/test/scala/de/thatscalaguy/zustellix/dvdv/auth/TokenManagerSpec.scala
+++ b/dvdv/src/test/scala/de/thatscalaguy/zustellix/dvdv/auth/TokenManagerSpec.scala
@@ -2,7 +2,7 @@ package de.thatscalaguy.zustellix.dvdv.auth
 
 import cats.effect.{IO, Ref}
 import cats.syntax.all.*
-import de.thatscalaguy.zustellix.dvdv.{DvdvConfig, DvdvError}
+import de.thatscalaguy.zustellix.dvdv.{DvdvConfig, DvdvError, TestCerts}
 import de.thatscalaguy.zustellix.utils.cert.{CertLoader, CertSource, LoadedCert}
 import io.circe.Json
 import munit.CatsEffectSuite
@@ -11,6 +11,7 @@ import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
 import org.http4s.client.Client
 import org.http4s.dsl.io.*
 import org.http4s.implicits.uri
+import pdi.jwt.{Jwt, JwtAlgorithm, JwtCirce, JwtOptions}
 
 import java.nio.file.Paths
 
@@ -57,11 +58,10 @@ class TokenManagerSpec extends CatsEffectSuite {
   test("happy path: posts the jwt-bearer form and returns the access token") {
     for {
       rec <- recorder
-      l   <- loaded
       tm  <- TokenManager.make[IO](
                tokenClient(rec)(_ => Ok(accessTokenJson("tok-123", 3600))),
                config,
-               l
+               loaded
              )
       tok  <- tm.bearer
       n    <- rec.count.get
@@ -89,11 +89,10 @@ class TokenManagerSpec extends CatsEffectSuite {
     )
     for {
       rec <- recorder
-      l   <- loaded
       tm  <- TokenManager.make[IO](
                tokenClient(rec)(_ => IO(Response[IO](Status.Unauthorized).withEntity(problem))),
                config,
-               l
+               loaded
              )
       res <- tm.bearer.attempt
     } yield res match {
@@ -106,11 +105,10 @@ class TokenManagerSpec extends CatsEffectSuite {
   test("caching: two bearer calls within the skew window trigger exactly one POST") {
     for {
       rec <- recorder
-      l   <- loaded
       tm  <- TokenManager.make[IO](
                tokenClient(rec)(_ => Ok(accessTokenJson("cached", 3600))),
                config,
-               l
+               loaded
              )
       a <- tm.bearer
       b <- tm.bearer
@@ -125,12 +123,11 @@ class TokenManagerSpec extends CatsEffectSuite {
   test("invalidate forces the next bearer to re-fetch (a second POST)") {
     for {
       rec <- recorder
-      l   <- loaded
       tm  <- TokenManager.make[IO](
                // each acquisition returns a distinct token so the refresh is observable
                tokenClient(rec)(n => Ok(accessTokenJson(s"tok-$n", 3600))),
                config,
-               l
+               loaded
              )
       first <- tm.bearer
       _     <- tm.invalidate
@@ -147,17 +144,75 @@ class TokenManagerSpec extends CatsEffectSuite {
     val N = 32
     for {
       rec <- recorder
-      l   <- loaded
       tm  <- TokenManager.make[IO](
                tokenClient(rec)(_ => Ok(accessTokenJson("once", 3600))),
                config,
-               l
+               loaded
              )
       toks <- tm.bearer.parReplicateA(N)
       n    <- rec.count.get
     } yield {
       assertEquals(toks.toSet, Set("once"))
       assertEquals(n, 1)
+    }
+  }
+
+  private def lastAssertion(rec: Recorder): IO[String] =
+    rec.lastForm.get.map(_.flatMap(_.values.get("client_assertion")).flatMap(_.headOption).get)
+
+  test("the cert is resolved once per token acquisition, not at construction") {
+    for {
+      rec      <- recorder
+      resolves <- Ref.of[IO, Int](0)
+      tm       <- TokenManager.make[IO](
+                    tokenClient(rec)(n => Ok(accessTokenJson(s"tok-$n", 3600))),
+                    config,
+                    resolves.update(_ + 1) *> loaded
+                  )
+      n0 <- resolves.get
+      _  <- tm.bearer
+      _  <- tm.bearer // still cached — no new resolution
+      n1 <- resolves.get
+      _  <- tm.invalidate
+      _  <- tm.bearer
+      n2 <- resolves.get
+    } yield {
+      assertEquals(n0, 0)
+      assertEquals(n1, 1)
+      assertEquals(n2, 2)
+    }
+  }
+
+  test("rotation: each token refresh signs the client_assertion with the freshly resolved cert") {
+    for {
+      rec     <- recorder
+      old     <- loaded
+      rotated <- TestCerts.mintLoadedCert("rotated")
+      current <- Ref.of[IO, LoadedCert](old)
+      tm      <- TokenManager.make[IO](
+                   tokenClient(rec)(n => Ok(accessTokenJson(s"tok-$n", 3600))),
+                   config,
+                   current.get
+                 )
+      _  <- tm.bearer
+      a1 <- lastAssertion(rec)
+      _  <- current.set(rotated) // the rotation
+      _  <- tm.invalidate        // e.g. the AuthMiddleware 401 path
+      _  <- tm.bearer
+      a2 <- lastAssertion(rec)
+    } yield {
+      def subject(jwt: String): Option[String] =
+        JwtCirce.decode(jwt, JwtOptions(signature = false)).toOption.flatMap(_.subject)
+      assertEquals(subject(a1), Some(s"fp:${old.fingerprintSha1Hex}"))
+      assertEquals(subject(a2), Some(s"fp:${rotated.fingerprintSha1Hex}"))
+      assert(
+        Jwt.isValid(a2, rotated.certificate.getPublicKey, Seq(JwtAlgorithm.RS256)),
+        "assertion after rotation must verify against the rotated key"
+      )
+      assert(
+        !Jwt.isValid(a2, old.certificate.getPublicKey, Seq(JwtAlgorithm.RS256)),
+        "assertion after rotation must no longer verify against the old key"
+      )
     }
   }
 }


### PR DESCRIPTION
Fixes #23

`DvdvClient.resource(config, certs, alias)` resolved the `LoadedCert` once when the client was built. `TokenManager` kept that cert as a fixed field and signed every `client_assertion` with the frozen key. After a rotation in `DirectoryCertManager` the token endpoint answered 401 until the process was restarted, which breaks the hot-reload contract of the cert manager.

## Changes

- `TokenManager.make` now takes `resolve: F[LoadedCert]` instead of a fixed `LoadedCert`. The effect runs inside `acquire`, so the cert is looked up once per token refresh. Together with the existing 401 retry in `AuthMiddleware` (invalidate + retry once), a rotation heals on the next request without a restart.
- The `certSource` constructors (`resource(config)`, `fromClient(config, http)`) load the cert once at build time and pass it as a fixed value. Nothing changes for them, including the fail-fast error when `certSource` is missing or broken.
- The `CertManager`/alias constructors still resolve the alias once at build time so an unknown alias fails fast, but they hand the unmemoized `certs.loadedCert(alias)` to the token manager. Every refresh signs with whatever cert the manager currently holds.
- README: short note on this behaviour in the dvdv constructors section.